### PR TITLE
[Feat] 장소에 대한 접근성 정보 반환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 dependencies {
 
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
+//    implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
@@ -38,6 +38,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    //s3
+    implementation platform("software.amazon.awssdk:bom:2.25.2")
+    implementation 'software.amazon.awssdk:s3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
@@ -1,0 +1,26 @@
+package com.cliptripbe.feature.place.api;
+
+import com.cliptripbe.feature.place.api.dto.PlaceAccessibilityInfoResponse;
+import com.cliptripbe.feature.place.application.PlaceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/places")
+public class PlaceController {
+
+    final PlaceService placeService;
+
+    @GetMapping("/{name}")
+    PlaceAccessibilityInfoResponse getPlaceAccessibilityInfo(
+        @PathVariable(value = "name") String placeName
+    ) {
+        PlaceAccessibilityInfoResponse accessibilityInfoResponses = placeService.getPlaceAccessibilityInfo(
+            placeName);
+        return accessibilityInfoResponses;
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/api/dto/PlaceAccessibilityInfoResponse.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/dto/PlaceAccessibilityInfoResponse.java
@@ -1,0 +1,18 @@
+package com.cliptripbe.feature.place.api.dto;
+
+import com.cliptripbe.feature.place.domain.AccessibilityFeature;
+import com.cliptripbe.feature.place.domain.Place;
+import java.util.List;
+
+public record PlaceAccessibilityInfoResponse(
+    String name,
+    List<AccessibilityFeature> accessibilityFeatures
+) {
+
+    public static PlaceAccessibilityInfoResponse from(Place place) {
+        return new PlaceAccessibilityInfoResponse(
+            place.getName(),
+            place.getAccessibilityFeatures()
+        );
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/api/dto/PlaceAccessibilityInfoResponse.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/dto/PlaceAccessibilityInfoResponse.java
@@ -3,16 +3,18 @@ package com.cliptripbe.feature.place.api.dto;
 import com.cliptripbe.feature.place.domain.AccessibilityFeature;
 import com.cliptripbe.feature.place.domain.Place;
 import java.util.List;
+import lombok.Builder;
 
+@Builder
 public record PlaceAccessibilityInfoResponse(
     String name,
     List<AccessibilityFeature> accessibilityFeatures
 ) {
 
     public static PlaceAccessibilityInfoResponse from(Place place) {
-        return new PlaceAccessibilityInfoResponse(
-            place.getName(),
-            place.getAccessibilityFeatures()
-        );
+        return PlaceAccessibilityInfoResponse.builder()
+            .name(place.getName())
+            .accessibilityFeatures(place.getAccessibilityFeatures())
+            .build();
     }
 }

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceFinder.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceFinder.java
@@ -1,0 +1,21 @@
+package com.cliptripbe.feature.place.application;
+
+import com.cliptripbe.feature.place.domain.Place;
+import com.cliptripbe.feature.place.infrastructure.PlaceRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class PlaceFinder {
+
+    final PlaceRepository placeRepository;
+
+    public Place getPlaceByName(String placeName) {
+        return placeRepository.findByName(placeName).orElseThrow(
+            () -> new EntityNotFoundException("없습니다.")
+        );
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceMapper.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceMapper.java
@@ -1,0 +1,75 @@
+package com.cliptripbe.feature.place.application;
+
+import com.cliptripbe.feature.place.domain.AccessibilityFeature;
+import com.cliptripbe.feature.place.domain.Address;
+import com.cliptripbe.feature.place.domain.Place;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PlaceMapper {
+
+    AccessibilityFeature[] featureEnums = {
+        AccessibilityFeature.FREE_PARKING,
+        AccessibilityFeature.PAID_PARKING,
+        AccessibilityFeature.ENTRANCE_FOR_DISABLED,
+        AccessibilityFeature.WHEELCHAIR_RENTAL,
+        AccessibilityFeature.DISABLED_TOILET,
+        AccessibilityFeature.EXCLUSIVE_PARKING,
+        AccessibilityFeature.LARGE_PARKING,
+        AccessibilityFeature.GUIDE_DOG_ALLOWED,
+        AccessibilityFeature.BRAILLE_GUIDE,
+        AccessibilityFeature.AUDIO_GUIDE_KR
+    };
+
+    public Place mapPlace(String placeInfo) {
+        String[] tokens = placeInfo.split(",");
+
+        // 기본 필드 추출
+        String name = tokens[0];
+
+        // Address 생성 (도로명주소, 우편번호, 위도, 경도)
+        String roadAddress = tokens[15];
+        String zipCode = tokens[14];
+        double latitude = parseDouble(tokens[12]);
+        double longitude = parseDouble(tokens[13]);
+
+        Address address =
+            Address.builder()
+                .latitude(latitude)
+                .longitude(longitude)
+                .zipCode(zipCode)
+                .roadAddress(roadAddress)
+                .build();
+        // AccessibilityFeature 추출
+
+        String[] flagFields = Arrays.copyOfRange(tokens, 24, 34); // 10개
+
+        List<AccessibilityFeature> features = new ArrayList<>();
+        for (int i = 0; i < flagFields.length; i++) {
+            String cleaned = flagFields[i].replace("\"", "").trim();
+            if ("Y".equalsIgnoreCase(cleaned)) {
+                features.add(featureEnums[i]);
+            }
+        }
+
+        // Place 생성
+        Place place = Place.builder()
+            .name(name)
+            .address(address)
+            .accessibilityFeatures(features)
+            .build();
+
+        return place;
+    }
+
+    private double parseDouble(String value) {
+        try {
+            return Double.parseDouble(value.trim());
+        } catch (NumberFormatException e) {
+            return 0.0;
+        }
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -1,0 +1,40 @@
+package com.cliptripbe.feature.place.application;
+
+import com.cliptripbe.feature.place.api.dto.PlaceAccessibilityInfoResponse;
+import com.cliptripbe.feature.place.domain.Place;
+import com.cliptripbe.feature.place.infrastructure.PlaceRepository;
+import com.cliptripbe.infrastructure.file.FileService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceService {
+
+    final PlaceFinder placeFinder;
+    final FileService fileService;
+    final PlaceMapper placeMapper;
+    final PlaceRepository placeRepository;
+
+    @Transactional
+    public PlaceAccessibilityInfoResponse getPlaceAccessibilityInfo(
+        String placeName) {
+        Place place;
+        try {
+            place = placeFinder.getPlaceByName(placeName);
+        } catch (EntityNotFoundException e) {
+            place = registerPlace(placeName);
+        }
+
+        return PlaceAccessibilityInfoResponse.from(place);
+    }
+
+    private Place registerPlace(String placeName) {
+        String placeInfo = fileService.findPlaceInfo(placeName);
+        Place place = placeMapper.mapPlace(placeInfo);
+        placeRepository.save(place);
+        return place;
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/domain/AccessibilityFeature.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/AccessibilityFeature.java
@@ -1,0 +1,23 @@
+package com.cliptripbe.feature.place.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum AccessibilityFeature {
+    FREE_PARKING("무료주차 가능"),
+    PAID_PARKING("유료주차 가능"),
+    ENTRANCE_FOR_DISABLED("장애인용 출입문"),
+    WHEELCHAIR_RENTAL("휠체어 대여"),
+    DISABLED_TOILET("장애인 화장실"),
+    EXCLUSIVE_PARKING("장애인 전용 주차장"),
+    LARGE_PARKING("대형 주차장"),
+    GUIDE_DOG_ALLOWED("시각장애인 안내견 동반 가능"),
+    BRAILLE_GUIDE("점자 가이드 제공"),
+    AUDIO_GUIDE_KR("오디오 가이드(한국어)");
+
+    private final String description;
+
+    AccessibilityFeature(String description) {
+        this.description = description;
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/domain/AccessibilityFeatureConverter.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/AccessibilityFeatureConverter.java
@@ -1,0 +1,36 @@
+package com.cliptripbe.feature.place.domain;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Converter
+public class AccessibilityFeatureConverter implements
+    AttributeConverter<List<AccessibilityFeature>, String> {
+
+    private static final String DELIMITER = ",";
+
+    @Override
+    public String convertToDatabaseColumn(List<AccessibilityFeature> attribute) {
+        if (attribute == null || attribute.isEmpty()) {
+            return "";
+        }
+        return attribute.stream()
+            .map(Enum::name) // enum -> String
+            .collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public List<AccessibilityFeature> convertToEntityAttribute(String dbData) {
+        if (dbData == null || dbData.isBlank()) {
+            return Collections.emptyList();
+        }
+        return Arrays.stream(dbData.split(DELIMITER))
+            .map(String::trim)
+            .map(AccessibilityFeature::valueOf)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/domain/AccessibilityInfo.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/AccessibilityInfo.java
@@ -1,0 +1,15 @@
+package com.cliptripbe.feature.place.domain;
+
+//@Entity
+//public class AccessibilityInfo {
+//
+//    @Id
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//
+//    @ManyToOne
+//    private Place place;
+//
+//    @ManyToOne
+//    private AccessibilityInfo accessibilityInfo;
+//}

--- a/src/main/java/com/cliptripbe/feature/place/domain/Address.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/Address.java
@@ -1,0 +1,15 @@
+package com.cliptripbe.feature.place.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.Builder;
+
+@Embeddable
+@Builder
+public record Address(
+    Double latitude,
+    Double longitude,
+    String zipCode,
+    String roadAddress
+) {
+
+}

--- a/src/main/java/com/cliptripbe/feature/place/domain/Place.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/Place.java
@@ -1,0 +1,43 @@
+package com.cliptripbe.feature.place.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Place {
+
+    @Id
+    @Column
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column
+    private String name;
+
+    @Column
+    @Embedded
+    private Address address;
+
+    @Column
+    @Convert(converter = AccessibilityFeatureConverter.class)
+    private List<AccessibilityFeature> accessibilityFeatures;
+
+    @Builder
+    public Place(String name, Address address,
+        List<AccessibilityFeature> accessibilityFeatures) {
+        this.name = name;
+        this.address = address;
+        this.accessibilityFeatures = accessibilityFeatures;
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/domain/PlaceAccessibilityInfo.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/PlaceAccessibilityInfo.java
@@ -1,0 +1,23 @@
+//package com.cliptripbe.feature.place.domain;
+//
+//import jakarta.persistence.Column;
+//import jakarta.persistence.Entity;
+//import jakarta.persistence.GeneratedValue;
+//import jakarta.persistence.GenerationType;
+//import jakarta.persistence.Id;
+//
+//@Entity
+//public class PlaceAccessibilityInfo {
+//
+//    @Id
+//    @Column
+//    @GeneratedValue(strategy = GenerationType.IDENTITY)
+//    private Long id;
+//
+//    @Column
+//    private String name;
+//
+//    @Column
+//    private String description;
+//
+//}

--- a/src/main/java/com/cliptripbe/feature/place/infrastructure/PlaceRepository.java
+++ b/src/main/java/com/cliptripbe/feature/place/infrastructure/PlaceRepository.java
@@ -1,0 +1,10 @@
+package com.cliptripbe.feature.place.infrastructure;
+
+import com.cliptripbe.feature.place.domain.Place;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+
+    Optional<Place> findByName(String placeName);
+}

--- a/src/main/java/com/cliptripbe/infrastructure/file/FileKind.java
+++ b/src/main/java/com/cliptripbe/infrastructure/file/FileKind.java
@@ -1,4 +1,4 @@
-package com.cliptripbe.infrastructure.file.reader;
+package com.cliptripbe.infrastructure.file;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/cliptripbe/infrastructure/file/FileService.java
+++ b/src/main/java/com/cliptripbe/infrastructure/file/FileService.java
@@ -1,6 +1,6 @@
 package com.cliptripbe.infrastructure.file;
 
-import static com.cliptripbe.infrastructure.file.reader.FileKind.BF_CULTURE_TOURISM;
+import static com.cliptripbe.infrastructure.file.FileKind.BF_CULTURE_TOURISM;
 
 import com.cliptripbe.infrastructure.s3.S3FileReader;
 import java.io.BufferedReader;

--- a/src/main/java/com/cliptripbe/infrastructure/file/FileService.java
+++ b/src/main/java/com/cliptripbe/infrastructure/file/FileService.java
@@ -1,0 +1,34 @@
+package com.cliptripbe.infrastructure.file;
+
+import static com.cliptripbe.infrastructure.file.reader.FileKind.BF_CULTURE_TOURISM;
+
+import com.cliptripbe.infrastructure.s3.S3FileReader;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FileService {
+
+    final S3FileReader fileReader;
+
+    public String findPlaceInfo(String placeName) {
+        try (BufferedReader br = fileReader.readCsv(BF_CULTURE_TOURISM.getFileName())) {
+            String line;
+            while ((line = br.readLine()) != null) {
+                if (line.contains(placeName)) {
+                    return line;
+                }
+            }
+        } catch (IOException e) {
+            // 예외 처리
+            e.printStackTrace();
+        }
+        throw new NoSuchElementException("존재하지 않는 장소입니다.");
+    }
+}

--- a/src/main/java/com/cliptripbe/infrastructure/file/reader/FileKind.java
+++ b/src/main/java/com/cliptripbe/infrastructure/file/reader/FileKind.java
@@ -1,0 +1,11 @@
+package com.cliptripbe.infrastructure.file.reader;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum FileKind {
+    BF_CULTURE_TOURISM("한국문화정보원_전국 배리어프리 문화예술관광지_20221125.csv");
+    final String fileName;
+}

--- a/src/main/java/com/cliptripbe/infrastructure/s3/S3Config.java
+++ b/src/main/java/com/cliptripbe/infrastructure/s3/S3Config.java
@@ -1,0 +1,31 @@
+package com.cliptripbe.infrastructure.s3;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+public class S3Config {
+
+    @Value("${s3.access-key}")
+    private String accessKey;
+
+    @Value("${s3.secret-key}")
+    private String secretKey;
+
+    @Value("${s3.region}")
+    private String region;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Client.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build();
+    }
+}

--- a/src/main/java/com/cliptripbe/infrastructure/s3/S3FileReader.java
+++ b/src/main/java/com/cliptripbe/infrastructure/s3/S3FileReader.java
@@ -1,0 +1,32 @@
+package com.cliptripbe.infrastructure.s3;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.GetObjectResponse;
+
+@Component
+@RequiredArgsConstructor
+public class S3FileReader {
+
+    private final S3Client s3Client;
+
+    @Value("${s3.bucket}")
+    private String bucket;
+
+    public BufferedReader readCsv(String key) {
+        GetObjectRequest request = GetObjectRequest.builder()
+            .bucket(bucket)
+            .key(key)
+            .build();
+
+        ResponseInputStream<GetObjectResponse> s3Stream = s3Client.getObject(request);
+        return new BufferedReader(new InputStreamReader(s3Stream, StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## ✅ 작업 내용

- 장소명을 받고, 한국문화정보원_전국 배리어프리 문화예술관광지 파일을 읽고 그 안에 존재한다면, 그 장소에 대한 접근 정보성 정보를 반환하는 API를 구현했습니다.

## 🤔 고민 했던 부분
- 1. 일단 Entity 연관관계가 가장 고민됩니다. 처음에는 정보 접근성도 객체로 만들어서 장소 - 중간테이블 - 정보 접근성 이 구조를 통해 하나의 장소가 여러 정보 접근성 엔터티를 갖도록 할려고 했습니다. 하지만 이런 공공데이터인 경우에는 csv 파일인 경우가 많아. 정보 접근성을 엔터티로 만들 때 구현 로직이 너무 복잡할 것 같습니다. (대부분 한 line으로 split을 통해 각 단어를 얻기 때문에)
그래서 그냥 Converter를 활용해서 ,를 구분자로 하여 저장하고 반환하는 식으로 구현을 했습니다.
- 2. 그리고 현재는 S3를 도입했습니다. 그렇기 때문에 반드시 노션에 올린 application.yml을 참고해주세요. 대용량 csv파일을 프로젝트내나 서버에 두는 것보다 S3에 두는 곳이 좋아보여서 S3로 올렸습니다.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
1. 위에서 말한 고민했던 부분 1번에 대해 어떻게 생각하는 지 궁금합니다. 의견이 궁금하여 연관관계로 했을 때의 코드를 아직 완벽히 지우지 않았습니다.

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.