### PR TITLE
[refactor] 기본 북마크 조회시 물품 보관소는 제외하도록 변경

### DIFF
--- a/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkFinder.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkFinder.java
@@ -1,5 +1,7 @@
 package com.cliptripbe.feature.bookmark.application;
 
+import static com.cliptripbe.infrastructure.inital.type.DefaultData.STORAGE_SEOUL;
+
 import com.cliptripbe.feature.bookmark.domain.entity.Bookmark;
 import com.cliptripbe.feature.bookmark.infrastructure.BookmarkRepository;
 import com.cliptripbe.global.response.exception.CustomException;
@@ -19,8 +21,8 @@ public class BookmarkFinder {
             ErrorType.ENTITY_NOT_FOUND));
     }
 
-    public List<Bookmark> getDefaultBookmark() {
-        return bookmarkRepository.findAllByUserIsNull();
+    public List<Bookmark> getDefaultBookmarksExcludingStorageSeoul() {
+        return bookmarkRepository.findDefaultBookmarksExcludingName(STORAGE_SEOUL.getName());
     }
 
 }

--- a/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
@@ -34,13 +34,13 @@ public class BookmarkService {
     private final PlaceTranslationFinder placeTranslationFinder;
 
     @Transactional
-    public Long createBookmark(User user, CreateBookmarkRequestDto request) {
-        Bookmark bookmark = Bookmark
-            .builder()
-            .name(request.bookmarkName())
-            .description(request.description())
-            .user(user)
-            .build();
+    public Long createBookmark(
+        User user,
+        CreateBookmarkRequestDto request
+    ) {
+        Bookmark bookmark = Bookmark.createByUser(request.bookmarkName(), request.description(),
+            user);
+        
         bookmarkRepository.save(bookmark);
         return bookmark.getId();
     }
@@ -125,13 +125,5 @@ public class BookmarkService {
             throw new CustomException(ErrorType.ACCESS_DENIED_EXCEPTION);
         }
         bookmarkRepository.delete(bookmark);
-    }
-
-    @Transactional(readOnly = true)
-    public List<BookmarkListResponseDto> getDefaultBookmarkList() {
-        List<Bookmark> defaultBookmark = bookmarkFinder.getDefaultBookmark();
-        return defaultBookmark.stream()
-            .map(BookmarkMapper::mapBookmarkListResponseDto)
-            .toList();
     }
 }

--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/Bookmark.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/Bookmark.java
@@ -3,6 +3,7 @@ package com.cliptripbe.feature.bookmark.domain.entity;
 import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.user.domain.User;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -23,24 +24,55 @@ public class Bookmark {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    Long id;
+    private Long id;
 
-    String name;
+    private String name;
 
-    String description;
+    private String description;
 
     @ManyToOne
-    User user;
+    private User user;
 
     @OneToMany(mappedBy = "bookmark", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<BookmarkPlace> bookmarkPlaces = new ArrayList<>();
 
+    @Column
+    private boolean isDefault;
+
     @Builder
-    public Bookmark(String name, String description, User user) {
+    public Bookmark(
+        String name,
+        String description,
+        User user,
+        boolean isDefault
+    ) {
         this.name = name;
         this.description = description;
         this.user = user;
+        this.isDefault = isDefault;
     }
+
+    public static Bookmark createByUser(
+        String name, String description, User user
+    ) {
+        return Bookmark.builder()
+            .name(name)
+            .description(description)
+            .user(user)
+            .isDefault(false)
+            .build();
+    }
+
+    public static Bookmark createDefault(
+        String name, String description
+    ) {
+        return Bookmark.builder()
+            .name(name)
+            .description(description)
+            .isDefault(true)
+            .build();
+    }
+
 
     public void addBookmarkPlace(BookmarkPlace bookmarkPlace) {
         this.bookmarkPlaces.add(bookmarkPlace);

--- a/src/main/java/com/cliptripbe/feature/bookmark/infrastructure/BookmarkRepository.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/infrastructure/BookmarkRepository.java
@@ -14,7 +14,9 @@ public interface BookmarkRepository extends JpaRepository<Bookmark, Long> {
 
     Optional<Bookmark> findByName(String s);
 
-    List<Bookmark> findAllByUserIsNull();
+    @Query("SELECT b FROM Bookmark b WHERE b.isDefault = true AND b.name != :excludedBookmarkName")
+    List<Bookmark> findDefaultBookmarksExcludingName(
+        @Param("excludedBookmarkName") String excludedBookmarkName);
 
     @Query("""
             SELECT COUNT(bp) > 0

--- a/src/main/java/com/cliptripbe/feature/user/application/UserService.java
+++ b/src/main/java/com/cliptripbe/feature/user/application/UserService.java
@@ -38,7 +38,9 @@ public class UserService {
         String encodePassword = passwordEncoder.encode(signUpDto.password());
         User user = signUpDto.toEntity(encodePassword);
         userRepository.save(user);
-        List<Bookmark> defaultBookmarks = bookmarkFinder.getDefaultBookmark();
+        List<Bookmark> defaultBookmarks = bookmarkFinder
+            .getDefaultBookmarksExcludingStorageSeoul();
+
         List<Bookmark> newUserBookmarks = new ArrayList<>();
 
         for (Bookmark bm : defaultBookmarks) {

--- a/src/main/java/com/cliptripbe/infrastructure/inital/initaler/BookmarkInitializer.java
+++ b/src/main/java/com/cliptripbe/infrastructure/inital/initaler/BookmarkInitializer.java
@@ -16,11 +16,8 @@ public class BookmarkInitializer {
     private final BookmarkRepository bookmarkRepository;
 
     public void initialBookmark(List<Place> placeList, DefaultData defaultData) {
-        Bookmark bookmark = Bookmark
-            .builder()
-            .name(defaultData.getName())
-            .description(defaultData.getDescription())
-            .build();
+        Bookmark bookmark = Bookmark.createDefault(defaultData.getName(),
+            defaultData.getDescription());
         for (Place place : placeList) {
             BookmarkPlace bookmarkPlace = BookmarkPlace
                 .builder()


### PR DESCRIPTION
## ✅ 작업 내용
- 리뷰어가 중점적으로 봐야하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 북마크에 기본 여부를 나타내는 필드가 추가되었습니다.

* **버그 수정**
  * 기본 북마크 목록에서 특정 이름(STORAGE_SEOUL)을 제외하도록 변경되었습니다.

* **리팩터링**
  * 북마크 생성 시 정적 팩토리 메서드 사용으로 코드 구조가 개선되었습니다.
  * 기본 북마크 조회 및 생성 로직이 명확하게 분리되었습니다.

* **기타**
  * 불필요한 메서드가 제거되고, 일부 메서드의 시그니처와 내부 구현이 정리되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->