### PR TITLE
[refactor]: 장소 추출시 사용자 언어에 따라 응답값 수정

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,7 +4,7 @@ reviews:
   profile: "chill"
   request_changes_workflow: false
   high_level_summary: true
-  poem: true
+  poem: false
   review_status: true
   collapse_walkthrough: false
   auto_review:

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceTranslationService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceTranslationService.java
@@ -18,14 +18,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class PlaceTranslationService {
 
     private final ChatGPTService chatGPTService;
     private final PlaceTranslationRepository placeTranslationRepository;
 
-
+    @Transactional
     public void registerPlace(Place place) {
         placeTranslationRepository.findByPlaceAndLanguage(place, ENGLISH)
             .orElseGet(() -> {

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceTranslationService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceTranslationService.java
@@ -11,19 +11,21 @@ import com.cliptripbe.infrastructure.openai.prompt.PromptConstants;
 import com.cliptripbe.infrastructure.openai.service.ChatGPTService;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 @RequiredArgsConstructor
 public class PlaceTranslationService {
 
     private final ChatGPTService chatGPTService;
     private final PlaceTranslationRepository placeTranslationRepository;
 
-    @Transactional
+
     public void registerPlace(Place place) {
         placeTranslationRepository.findByPlaceAndLanguage(place, ENGLISH)
             .orElseGet(() -> {
@@ -34,7 +36,8 @@ public class PlaceTranslationService {
                     .roadAddress(translationInfo.translatedRoadAddress())
                     .language(ENGLISH)
                     .build();
-                return placeTranslationRepository.save(translation);
+                place.addTranslation(translation);
+                return placeTranslationRepository.saveAndFlush(translation);
             });
     }
 

--- a/src/main/java/com/cliptripbe/feature/place/domain/entity/Place.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/entity/Place.java
@@ -17,6 +17,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import lombok.Builder;
@@ -55,7 +56,7 @@ public class Place extends BaseTimeEntity {
     private String imageUrl;
 
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL)
-    private Set<PlaceTranslation> placeTranslations;
+    private Set<PlaceTranslation> placeTranslations = new HashSet<>();
 
     @Builder
     public Place(
@@ -83,5 +84,10 @@ public class Place extends BaseTimeEntity {
             .filter(pt -> pt.getLanguage() == language)
             .findFirst()
             .orElse(null);
+    }
+
+    public void addTranslation(PlaceTranslation translation) {
+        placeTranslations.add(translation);
+        translation.addPlace(this);
     }
 }

--- a/src/main/java/com/cliptripbe/feature/place/domain/entity/PlaceTranslation.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/entity/PlaceTranslation.java
@@ -33,4 +33,8 @@ public class PlaceTranslation {
     private String name;
 
     private String roadAddress;
+
+    public void addPlace(Place place) {
+        this.place = place;
+    }
 }

--- a/src/main/java/com/cliptripbe/feature/schedule/domain/impl/ScheduleFinder.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/domain/impl/ScheduleFinder.java
@@ -24,9 +24,4 @@ public class ScheduleFinder {
         return scheduleRepository.findByIdWithSchedulePlacesAndTranslations(scheduleId)
             .orElseThrow(() -> new CustomException(ErrorType.ENTITY_NOT_FOUND));
     }
-
-    public Schedule getScheduleById(Long scheduleId) {
-        return scheduleRepository.findById(scheduleId)
-            .orElseThrow(() -> new CustomException(ErrorType.ENTITY_NOT_FOUND));
-    }
 }

--- a/src/main/java/com/cliptripbe/feature/video/api/dto/response/VideoScheduleResponse.java
+++ b/src/main/java/com/cliptripbe/feature/video/api/dto/response/VideoScheduleResponse.java
@@ -18,15 +18,8 @@ public record VideoScheduleResponse(
     ScheduleInfoResponseDto scheduleInfoResponse
 ) {
 
-    public static VideoScheduleResponse of(Video video, Schedule schedule, Language language) {
-        List<PlaceListResponseDto> placeListResponseDtos = schedule.getSchedulePlaceList().stream()
-            .map(sp -> {
-                Place place = sp.getPlace();
-                Integer placeOrder = sp.getPlaceOrder();
-                PlaceTranslation translation = place.getTranslationByLanguage(language);
-                return PlaceListResponseDto.of(place, translation, placeOrder);
-            })
-            .toList();
+    public static VideoScheduleResponse of(Video video, Schedule schedule,
+        List<PlaceListResponseDto> placeListResponseDtos) {
 
         return VideoScheduleResponse.builder()
             .videoResponse(VideoResponseDto.from(video))

--- a/src/main/java/com/cliptripbe/feature/video/application/VideoService.java
+++ b/src/main/java/com/cliptripbe/feature/video/application/VideoService.java
@@ -114,7 +114,8 @@ public class VideoService {
 
         Schedule scheduleEntity = scheduleFinder.getByIdWithSchedulePlacesAndTranslations(
             schedule.getId());
-        List<PlaceListResponseDto> placeListResponseDtos = schedule.getSchedulePlaceList().stream()
+
+        List<PlaceListResponseDto> placeListResponseDtos = scheduleEntity.getSchedulePlaceList().stream()
             .map(sp -> {
                 Place place = sp.getPlace();
                 Integer placeOrder = sp.getPlaceOrder();

--- a/src/main/java/com/cliptripbe/feature/video/application/VideoService.java
+++ b/src/main/java/com/cliptripbe/feature/video/application/VideoService.java
@@ -48,7 +48,6 @@ public class VideoService {
     private final PlaceRegister placeRegister;
     private final VideoRepository videoRepository;
     private final PlaceTranslationService placeTranslationService;
-    private final EntityManager entityManager;
 
     private final ChatGPTService chatGPTService;
     private final KakaoMapService kakaoMapService;

--- a/src/main/java/com/cliptripbe/feature/video/application/VideoService.java
+++ b/src/main/java/com/cliptripbe/feature/video/application/VideoService.java
@@ -4,9 +4,11 @@ import static com.cliptripbe.global.response.type.ErrorType.CHATGPT_NO_RESPONSE;
 import static com.cliptripbe.global.response.type.ErrorType.KAKAO_MAP_NO_RESPONSE;
 
 import com.cliptripbe.feature.place.api.dto.PlaceDto;
+import com.cliptripbe.feature.place.api.dto.response.PlaceListResponseDto;
 import com.cliptripbe.feature.place.application.PlaceRegister;
 import com.cliptripbe.feature.place.application.PlaceTranslationService;
 import com.cliptripbe.feature.place.domain.entity.Place;
+import com.cliptripbe.feature.place.domain.entity.PlaceTranslation;
 import com.cliptripbe.feature.schedule.application.ScheduleRegister;
 import com.cliptripbe.feature.schedule.domain.entity.Schedule;
 import com.cliptripbe.feature.schedule.domain.entity.SchedulePlace;
@@ -26,6 +28,7 @@ import com.cliptripbe.infrastructure.kakao.service.KakaoMapService;
 import com.cliptripbe.infrastructure.openai.service.ChatGPTService;
 import com.cliptripbe.infrastructure.openai.prompt.PromptConstants;
 import com.cliptripbe.global.util.ChatGPTUtils;
+import jakarta.persistence.EntityManager;
 import java.util.List;
 import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
@@ -45,6 +48,7 @@ public class VideoService {
     private final PlaceRegister placeRegister;
     private final VideoRepository videoRepository;
     private final PlaceTranslationService placeTranslationService;
+    private final EntityManager entityManager;
 
     private final ChatGPTService chatGPTService;
     private final KakaoMapService kakaoMapService;
@@ -108,12 +112,17 @@ public class VideoService {
             )
             .forEach(schedule::addSchedulePlace);
 
-//        Schedule scheduleEntity = scheduleFinder.findByIdWithSchedulePlacesAndTranslations(
-//            schedule.getId(),
-//            user.getLanguage()
-//        );
+        Schedule scheduleEntity = scheduleFinder.getByIdWithSchedulePlacesAndTranslations(
+            schedule.getId());
+        List<PlaceListResponseDto> placeListResponseDtos = schedule.getSchedulePlaceList().stream()
+            .map(sp -> {
+                Place place = sp.getPlace();
+                Integer placeOrder = sp.getPlaceOrder();
+                PlaceTranslation translation = place.getTranslationByLanguage(user.getLanguage());
+                return PlaceListResponseDto.of(place, translation, placeOrder);
+            })
+            .toList();
 
-        Schedule scheduleEntity = scheduleFinder.getScheduleById(schedule.getId());
-        return VideoScheduleResponse.of(video, scheduleEntity, user.getLanguage());
+        return VideoScheduleResponse.of(video, scheduleEntity, placeListResponseDtos);
     }
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 리뷰어가 중점적으로 봐야하는 부분을 바로 알 수 있도록 변경된 내용을 나열합니다.

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **버그 수정**
  * 장소 번역 등록 시 번역 정보가 즉시 저장되고, 장소와 번역 간의 연관 관계가 올바르게 설정됩니다.

* **리팩터**
  * 장소 번역 서비스의 트랜잭션 처리가 클래스 단위로 일원화되었습니다.
  * 장소 엔터티의 번역 리스트가 기본값으로 초기화되고, 번역 추가 메서드가 도입되었습니다.
  * 일정 조회 기능에서 불필요한 메서드가 제거되었습니다.
  * 동영상 일정 응답 생성 시, 장소 리스트 DTO를 직접 주입받도록 변경되었습니다.
  * 동영상 서비스에서 일정 및 장소 번역 정보를 포함한 상세 응답이 제공됩니다.

* **기타**
  * 리뷰 과정에서 시 생성 기능이 비활성화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->