### PR TITLE
[CTTSK-10] feat: 유튜브 섬네일 추가 및 외부 서버 예외 핸들링

### DIFF
--- a/src/main/java/com/cliptripbe/feature/video/application/VideoPlaceExtractFacade.java
+++ b/src/main/java/com/cliptripbe/feature/video/application/VideoPlaceExtractFacade.java
@@ -12,7 +12,6 @@ import com.cliptripbe.feature.video.domain.entity.Video;
 import com.cliptripbe.feature.video.dto.request.ExtractPlaceRequest;
 import com.cliptripbe.feature.video.dto.response.VideoScheduleResponse;
 import com.cliptripbe.global.util.ChatGPTUtils;
-import com.cliptripbe.global.util.YoutubeUtils;
 import com.cliptripbe.infrastructure.adapter.out.caption.dto.CaptionResponse;
 import com.cliptripbe.infrastructure.port.kakao.KakaoMapPort;
 import com.cliptripbe.global.util.prompt.PromptUtils;

--- a/src/main/java/com/cliptripbe/feature/video/application/VideoPlaceExtractFacade.java
+++ b/src/main/java/com/cliptripbe/feature/video/application/VideoPlaceExtractFacade.java
@@ -12,6 +12,7 @@ import com.cliptripbe.feature.video.domain.entity.Video;
 import com.cliptripbe.feature.video.dto.request.ExtractPlaceRequest;
 import com.cliptripbe.feature.video.dto.response.VideoScheduleResponse;
 import com.cliptripbe.global.util.ChatGPTUtils;
+import com.cliptripbe.global.util.YoutubeUtils;
 import com.cliptripbe.infrastructure.adapter.out.caption.dto.CaptionResponse;
 import com.cliptripbe.infrastructure.port.kakao.KakaoMapPort;
 import com.cliptripbe.global.util.prompt.PromptUtils;
@@ -46,11 +47,9 @@ public class VideoPlaceExtractFacade {
         String gptPlaceResponse = chatGptPort.askPlaceExtraction(requestPlacePrompt);
         List<String> extractPlacesText = ChatGPTUtils.extractPlaces(gptPlaceResponse);
 
-        // 자막 요약
         String gptSummaryResponse = chatGptPort.ask(requestSummaryPrompt);
         String summaryKo = ChatGPTUtils.removeLiteralNewlines(gptSummaryResponse);
 
-        // 자막 요약 영어
         String summaryTranslated = null;
         if (user.getLanguage() == Language.ENGLISH) {
             String requestSummaryEnPrompt = PromptUtils.build(PromptType.SUMMARY_EN,

--- a/src/main/java/com/cliptripbe/feature/video/dto/request/ExtractPlaceRequest.java
+++ b/src/main/java/com/cliptripbe/feature/video/dto/request/ExtractPlaceRequest.java
@@ -1,7 +1,7 @@
 package com.cliptripbe.feature.video.dto.request;
 
 import com.cliptripbe.feature.video.domain.entity.Video;
-import com.cliptripbe.global.util.CaptionUtils;
+import com.cliptripbe.global.util.YoutubeUtils;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 
@@ -18,7 +18,7 @@ public record ExtractPlaceRequest(
         if (summaryTranslated != null) {
             return Video.builder()
                 .url(youtubeUrl)
-                .youtubeVideoId(CaptionUtils.extractVideoId(youtubeUrl))
+                .youtubeVideoId(YoutubeUtils.extractVideoId(youtubeUrl))
                 .summaryKo(summaryKo)
                 .summaryTranslated(summaryTranslated)
                 .translatedLang("ENGLISH")
@@ -26,7 +26,7 @@ public record ExtractPlaceRequest(
         }
         return Video.builder()
             .url(youtubeUrl)
-            .youtubeVideoId(CaptionUtils.extractVideoId(youtubeUrl))
+            .youtubeVideoId(YoutubeUtils.extractVideoId(youtubeUrl))
             .summaryKo(summaryKo)
             .build();
     }

--- a/src/main/java/com/cliptripbe/feature/video/dto/response/VideoResponse.java
+++ b/src/main/java/com/cliptripbe/feature/video/dto/response/VideoResponse.java
@@ -1,12 +1,14 @@
 package com.cliptripbe.feature.video.dto.response;
 
 import com.cliptripbe.feature.video.domain.entity.Video;
+import com.cliptripbe.global.util.YoutubeUtils;
 import lombok.Builder;
 
 @Builder
 public record VideoResponse(
     Long videoId,
     String url,
+    String thumbnailUrl,
     String summary
 ) {
 
@@ -18,6 +20,7 @@ public record VideoResponse(
         return VideoResponse.builder()
             .videoId(video.getId())
             .url(video.getUrl())
+            .thumbnailUrl(YoutubeUtils.getThumbnailUrl(video.getYoutubeVideoId()))
             .summary(summaryText)
             .build();
     }

--- a/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
+++ b/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
@@ -10,6 +10,7 @@ public enum ErrorType {
 
     //common
     ENUM_RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이넘 값을 찾을 수 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
 
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     ENTITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "요청한 정보로 엔터티를 찾을 수 없습니다."),
@@ -29,12 +30,14 @@ public enum ErrorType {
     // video
     CHATGPT_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "ChatGPT로부터 응답을 받지 못했습니다."),
     KAKAO_MAP_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "kakaoMap으로부터 응답을 받지 못했습니다."),
+    CAPTION_DISABLED(HttpStatus.FORBIDDEN, "동영상의 자막이 비활성화 되어있습니다. 다른 영상을 넣어주세요."),
+    CAPTION_SERVER_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "Caption 추출 서버로부터 응답을 받지 못했습니다."),
 
     // google api
     GOOGLE_PLACES_EMPTY_RESPONSE(HttpStatus.NOT_FOUND, "해당 주소로 검색된 장소 또는 사진이 없습니다."),
     GOOGLE_PLACES_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "google places로부터 응답을 받지 못했습니다."),
 
-    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다.");
+    ;
 
     private final HttpStatus httpStatusCode;
     private final String message;

--- a/src/main/java/com/cliptripbe/global/util/YoutubeUtils.java
+++ b/src/main/java/com/cliptripbe/global/util/YoutubeUtils.java
@@ -3,7 +3,7 @@ package com.cliptripbe.global.util;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CaptionUtils {
+public class YoutubeUtils {
 
     private static final Pattern YT_PATTERN = Pattern.compile(
         "(?:https?://)?(?:www\\.)?" +
@@ -17,5 +17,9 @@ public class CaptionUtils {
             return matcher.group(1);
         }
         throw new IllegalArgumentException("유효한 YouTube URL이 아닙니다: " + url);
+    }
+
+    public static String getThumbnailUrl(String videoId) {
+        return String.format("https://img.youtube.com/vi/%s/hqdefault.jpg", videoId);
     }
 }

--- a/src/main/java/com/cliptripbe/infrastructure/adapter/out/caption/CaptionAdapter.java
+++ b/src/main/java/com/cliptripbe/infrastructure/adapter/out/caption/CaptionAdapter.java
@@ -1,11 +1,16 @@
 package com.cliptripbe.infrastructure.adapter.out.caption;
 
+import static com.cliptripbe.global.response.type.ErrorType.CAPTION_DISABLED;
+import static com.cliptripbe.global.response.type.ErrorType.CAPTION_SERVER_NO_RESPONSE;
+
+import com.cliptripbe.global.response.exception.CustomException;
 import com.cliptripbe.infrastructure.adapter.out.caption.dto.CaptionResponse;
 import com.cliptripbe.infrastructure.port.caption.CaptionPort;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestClient;
 
 
@@ -13,6 +18,7 @@ import org.springframework.web.client.RestClient;
 @Component
 @RequiredArgsConstructor
 public class CaptionAdapter implements CaptionPort {
+    private static final String CAPTION_DISABLED_MESSAGE = "자막이 비활성화";
 
     @Qualifier("captionsRestClient")
     private final RestClient captionsRestClient;
@@ -21,17 +27,26 @@ public class CaptionAdapter implements CaptionPort {
     public CaptionResponse getCaptions(String youtubeUrl) {
         long start = System.currentTimeMillis();
 
-        CaptionResponse captionResponse = captionsRestClient.get()
-            .uri(uriBuilder -> uriBuilder
-                .path("/captions")
-                .queryParam("video_url", youtubeUrl)
-                .queryParam("langs", "ko,en")
-                .build())
-            .retrieve()
-            .body(CaptionResponse.class);
+        try {
+            CaptionResponse captionResponse = captionsRestClient.get()
+                .uri(uriBuilder -> uriBuilder
+                    .path("/captions")
+                    .queryParam("video_url", youtubeUrl)
+                    .queryParam("langs", "ko,en")
+                    .build())
+                .retrieve()
+                .body(CaptionResponse.class);
 
-        long elapsed = System.currentTimeMillis() - start;
-        log.info("자막 추출 레이턴시: {} ms", elapsed);
-        return captionResponse;
+            long elapsed = System.currentTimeMillis() - start;
+            log.info("자막 추출 레이턴시: {} ms", elapsed);
+            return captionResponse;
+
+        } catch (HttpClientErrorException e) {
+            String responseBody = e.getResponseBodyAsString();
+            if (responseBody.contains(CAPTION_DISABLED_MESSAGE)) {
+                throw new CustomException(CAPTION_DISABLED);
+            }
+            throw new CustomException(CAPTION_SERVER_NO_RESPONSE);
+        }
     }
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 유튜브 섬네일 응답 값 추가했습니다.
- 자막 추출 서버로부터 받는 예외에 대해 핸들링 하였습니다

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 동영상 응답에 YouTube 썸네일 URL이 추가되었습니다.

* **버그 수정**
  * 자막이 비활성화된 동영상이나 자막 추출 서버 미응답 시, 명확한 오류 메시지가 제공됩니다.

* **기타**
  * 유틸리티 클래스 명칭이 변경되었으며, 썸네일 URL 추출 기능이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->