### PR TITLE
[CTTSK-19] fix: youtube url validate 패턴 수정

### DIFF
--- a/src/main/java/com/cliptripbe/feature/video/api/VideoController.java
+++ b/src/main/java/com/cliptripbe/feature/video/api/VideoController.java
@@ -33,6 +33,6 @@ public class VideoController implements VideoControllerDocs {
             customerDetails.getUser(),
             request
         );
-        return ApiResponse.success(SuccessType.CREATED, videoScheduleResponse);
+        return ApiResponse.success(SuccessType.OK, videoScheduleResponse);
     }
 }

--- a/src/main/java/com/cliptripbe/feature/video/application/VideoPlaceExtractFacade.java
+++ b/src/main/java/com/cliptripbe/feature/video/application/VideoPlaceExtractFacade.java
@@ -40,8 +40,7 @@ public class VideoPlaceExtractFacade {
 
         String requestPlacePrompt = PromptUtils.build(PromptType.PLACE, caption.captions());
 
-        String requestSummaryPrompt = PromptUtils.build(PromptType.SUMMARY_KO,
-            caption.captions());
+        String requestSummaryPrompt = PromptUtils.build(PromptType.SUMMARY_KO, caption.captions());
 
         String gptPlaceResponse = aiTextProcessorPort.askPlaceExtraction(requestPlacePrompt);
         List<String> extractPlacesText = ChatGPTUtils.extractPlaces(gptPlaceResponse);

--- a/src/main/java/com/cliptripbe/feature/video/dto/request/ExtractPlaceRequest.java
+++ b/src/main/java/com/cliptripbe/feature/video/dto/request/ExtractPlaceRequest.java
@@ -8,7 +8,10 @@ import jakarta.validation.constraints.Pattern;
 public record ExtractPlaceRequest(
     @NotBlank
     @Pattern(
-        regexp = "(?:https?://)?(?:www\\.)?(?:youtube\\.com/(?:watch\\?v=|embed/|shorts/)|youtu\\.be/)([A-Za-z0-9_-]{11})",
+        regexp = "(?:https?://)?(?:www\\.)?"
+            + "(?:youtube\\.com/(?:watch\\?v=|embed/|shorts/)|youtu\\.be/)"
+            + "([A-Za-z0-9_-]{11})"
+            + "(?:\\?.*)?",
         message = "유효한 YouTube URL이 아닙니다."
     )
     String youtubeUrl

--- a/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
+++ b/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
@@ -32,6 +32,7 @@ public enum ErrorType {
     KAKAO_MAP_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "kakaoMap으로부터 응답을 받지 못했습니다."),
     CAPTION_DISABLED(HttpStatus.FORBIDDEN, "동영상의 자막이 비활성화 되어있습니다. 다른 영상을 넣어주세요."),
     CAPTION_SERVER_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "Caption 추출 서버로부터 응답을 받지 못했습니다."),
+    INVALID_YOUTUBE_URL(HttpStatus.BAD_REQUEST, "유효한 YouTube URL이 아닙니다."),
 
     // google api
     GOOGLE_PLACES_EMPTY_RESPONSE(HttpStatus.NOT_FOUND, "해당 주소로 검색된 장소 또는 사진이 없습니다."),

--- a/src/main/java/com/cliptripbe/global/util/YoutubeUtils.java
+++ b/src/main/java/com/cliptripbe/global/util/YoutubeUtils.java
@@ -8,7 +8,8 @@ public class YoutubeUtils {
     private static final Pattern YT_PATTERN = Pattern.compile(
         "(?:https?://)?(?:www\\.)?" +
             "(?:youtube\\.com/(?:(?:watch\\?v=)|(?:embed/)|(?:shorts/))|youtu\\.be/)" +
-            "([A-Za-z0-9_-]{11})"
+            "([A-Za-z0-9_-]{11})" +
+            "(?:\\?.*)?"
     );
 
     public static String extractVideoId(String url) {

--- a/src/main/java/com/cliptripbe/global/util/YoutubeUtils.java
+++ b/src/main/java/com/cliptripbe/global/util/YoutubeUtils.java
@@ -1,5 +1,8 @@
 package com.cliptripbe.global.util;
 
+import static com.cliptripbe.global.response.type.ErrorType.INVALID_YOUTUBE_URL;
+
+import com.cliptripbe.global.response.exception.CustomException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -17,7 +20,7 @@ public class YoutubeUtils {
         if (matcher.find()) {
             return matcher.group(1);
         }
-        throw new IllegalArgumentException("유효한 YouTube URL이 아닙니다: " + url);
+        throw new CustomException(INVALID_YOUTUBE_URL);
     }
 
     public static String getThumbnailUrl(String videoId) {


### PR DESCRIPTION
## ✅ 작업 내용
- youtube url에서 id 추출시 불가능한 패턴이 있어서 수정하였습니다

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * YouTube URL에 쿼리 파라미터가 포함된 경우도 정상적으로 인식하도록 개선되었습니다.
  * 유효하지 않은 YouTube URL 입력 시, 보다 명확한 오류 메시지가 제공됩니다.

* **기타**
  * 일부 응답 상태 코드가 일반 성공(OK)으로 변경되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->