### PR TITLE
[CTTSK-25] refactor: 북마크 장소 관련한 api 추가 및 수정

### DIFF
--- a/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkController.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkController.java
@@ -17,6 +17,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.Mapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -44,15 +46,12 @@ public class BookmarkController implements BookmarkControllerDocs {
     }
 
     @Override
-    @PutMapping("/{bookmarkId}")
+    @PatchMapping("/{bookmarkId}")
     public ApiResponse<Long> updateBookmark(
         @PathVariable(value = "bookmarkId") Long bookmarkId,
         @RequestBody UpdateBookmarkRequest updateBookmarkRequest
     ) {
-        bookmarkService.updateBookmark(
-            bookmarkId,
-            updateBookmarkRequest
-        );
+        bookmarkService.updateBookmark(bookmarkId, updateBookmarkRequest);
         return ApiResponse.success(SuccessType.OK, bookmarkId);
     }
 
@@ -72,7 +71,7 @@ public class BookmarkController implements BookmarkControllerDocs {
     }
 
     @Override
-    @PostMapping("/{bookmarkId}/{placeId}")
+    @DeleteMapping("/{bookmarkId}/{placeId}")
     public ApiResponse<Long> deletePlaceFromBookmark(
         @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable(value = "bookmarkId") Long bookmarkId,

--- a/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkController.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkController.java
@@ -98,9 +98,11 @@ public class BookmarkController implements BookmarkControllerDocs {
         @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable Long bookmarkId
     ) {
-        BookmarkInfoResponse responseDto = bookmarkService.getBookmarkInfo(bookmarkId,
-            customerDetails.getUser());
-        return ApiResponse.success(SuccessType.OK, responseDto);
+        BookmarkInfoResponse response = bookmarkService.getBookmarkInfo(
+            bookmarkId,
+            customerDetails.getUser()
+        );
+        return ApiResponse.success(SuccessType.OK, response);
     }
 
     @Override

--- a/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkController.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkController.java
@@ -58,7 +58,7 @@ public class BookmarkController implements BookmarkControllerDocs {
 
     @Override
     @PostMapping("/{bookmarkId}")
-    public ApiResponse<Long> addBookmark(
+    public ApiResponse<Long> addPlaceToBookmark(
         @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable Long bookmarkId,
         @RequestBody PlaceInfoRequest placeInfoRequest
@@ -69,6 +69,17 @@ public class BookmarkController implements BookmarkControllerDocs {
             placeInfoRequest
         );
         return ApiResponse.success(SuccessType.OK, bookmarkId);
+    }
+
+    @Override
+    @PostMapping("/{bookmarkId}/{placeId}")
+    public ApiResponse<Long> deletePlaceFromBookmark(
+        @AuthenticationPrincipal CustomerDetails customerDetails,
+        @PathVariable(value = "bookmarkId") Long bookmarkId,
+        @PathVariable(value = "placeId") Long placeId
+    ) {
+        bookmarkService.deletePlaceFromBookmark(customerDetails.getUser(), bookmarkId, placeId);
+        return ApiResponse.success(SuccessType.OK, placeId);
     }
 
 
@@ -84,7 +95,7 @@ public class BookmarkController implements BookmarkControllerDocs {
 
     @Override
     @GetMapping("/{bookmarkId}")
-    public ApiResponse<BookmarkInfoResponse> getBookmarkInfo(
+    public ApiResponse<BookmarkInfoResponse> getBookmarkById(
         @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable Long bookmarkId
     ) {

--- a/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkController.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkController.java
@@ -62,7 +62,7 @@ public class BookmarkController implements BookmarkControllerDocs {
         @PathVariable Long bookmarkId,
         @RequestBody PlaceInfoRequest placeInfoRequest
     ) {
-        bookmarkService.addBookmark(
+        bookmarkService.addPlaceToBookmark(
             customerDetails.getUser(),
             bookmarkId,
             placeInfoRequest

--- a/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkControllerDocs.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/api/BookmarkControllerDocs.java
@@ -25,17 +25,24 @@ public interface BookmarkControllerDocs {
     );
 
     @Operation(summary = "북마크에 하나의 장소 추가하기, \n로그인 필요")
-    ApiResponse<Long> addBookmark(
+    ApiResponse<Long> addPlaceToBookmark(
         CustomerDetails customerDetails,
         Long bookmarkId,
         PlaceInfoRequest placeInfoRequest
     );
 
+    @Operation(summary = "북마크에 하나의 장소 삭제하기, \n로그인 필요")
+    ApiResponse<Long> deletePlaceFromBookmark(
+        CustomerDetails customerDetails,
+        Long bookmarkId,
+        Long placeId
+    );
+
     @Operation(summary = "유저 북마크 전체 조회하기, \n로그인 필요")
     ApiResponse<List<BookmarkListResponse>> getUserBookmark(CustomerDetails customerDetails);
 
-    @Operation(summary = "북마크안의 장소 리스트 조회하기, \n로그인 필요")
-    ApiResponse<BookmarkInfoResponse> getBookmarkInfo(
+    @Operation(summary = "북마크 상세 조회하기, \n로그인 필요")
+    ApiResponse<BookmarkInfoResponse> getBookmarkById(
         CustomerDetails customerDetails,
         Long bookmarkId
     );

--- a/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
@@ -60,6 +60,7 @@ public class BookmarkService {
         if (request.description() != null) {
             bookmark.modifyInfo(bookmark.getName(), request.description());
         }
+
         if (request.placeInfoRequests() != null) {
             bookmark.cleanBookmarkPlace();
             for (PlaceInfoRequest placeInfoRequest : request.placeInfoRequests()) {
@@ -121,7 +122,7 @@ public class BookmarkService {
 
         if (user.getLanguage() == KOREAN) {
             Bookmark bookmark = bookmarkFinder.findById(bookmarkId);
-            return BookmarkMapper.mapBookmarkInfoResponse(bookmark);
+            return BookmarkInfoResponse.from(bookmark);
         }
         Bookmark bookmark = bookmarkFinder.findByIdWithPlacesAndTranslations(bookmarkId);
 

--- a/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
@@ -50,24 +50,26 @@ public class BookmarkService {
     }
 
     @Transactional
-    public void updateBookmark(
-        Long bookmarkId,
-        UpdateBookmarkRequest updateBookmarkRequest
-    ) {
+    public void updateBookmark(Long bookmarkId, UpdateBookmarkRequest request) {
         Bookmark bookmark = bookmarkFinder.findById(bookmarkId);
 
-        bookmark.modifyInfo(updateBookmarkRequest.bookmarkName(),
-            updateBookmarkRequest.description());
-        bookmark.cleanBookmarkPlace();
+        if (request.bookmarkName() != null) {
+            bookmark.modifyInfo(request.bookmarkName(), bookmark.getDescription());
+        }
 
-        for (PlaceInfoRequest placeInfoRequest : updateBookmarkRequest.placeInfoRequests()) {
-            Place place = placeService.findOrCreatePlaceByPlaceInfo(placeInfoRequest);
-            BookmarkPlace bookmarkPlace = BookmarkPlace
-                .builder()
-                .bookmark(bookmark)
-                .place(place)
-                .build();
-            bookmark.addBookmarkPlace(bookmarkPlace);
+        if (request.description() != null) {
+            bookmark.modifyInfo(bookmark.getName(), request.description());
+        }
+        if (request.placeInfoRequests() != null) {
+            bookmark.cleanBookmarkPlace();
+            for (PlaceInfoRequest placeInfoRequest : request.placeInfoRequests()) {
+                Place place = placeService.findOrCreatePlaceByPlaceInfo(placeInfoRequest);
+                BookmarkPlace bookmarkPlace = BookmarkPlace.builder()
+                    .bookmark(bookmark)
+                    .place(place)
+                    .build();
+                bookmark.addBookmarkPlace(bookmarkPlace);
+            }
         }
     }
 

--- a/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
@@ -75,7 +75,7 @@ public class BookmarkService {
     }
 
     @Transactional
-    public void addBookmark(User user, Long bookmarkId, PlaceInfoRequest placeInfoRequest) {
+    public void addPlaceToBookmark(User user, Long bookmarkId, PlaceInfoRequest placeInfoRequest) {
         Bookmark bookmark = bookmarkFinder.findById(bookmarkId);
 
         if (!bookmark.getUser().getId().equals(user.getId())) {
@@ -84,8 +84,7 @@ public class BookmarkService {
 
         Place place = placeService.findOrCreatePlaceByPlaceInfo(placeInfoRequest);
 
-        BookmarkPlace bookmarkPlace = BookmarkPlace
-            .builder()
+        BookmarkPlace bookmarkPlace = BookmarkPlace.builder()
             .bookmark(bookmark)
             .place(place)
             .build();

--- a/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/application/BookmarkService.java
@@ -53,12 +53,12 @@ public class BookmarkService {
     public void updateBookmark(Long bookmarkId, UpdateBookmarkRequest request) {
         Bookmark bookmark = bookmarkFinder.findById(bookmarkId);
 
-        if (request.bookmarkName() != null) {
-            bookmark.modifyInfo(request.bookmarkName(), bookmark.getDescription());
-        }
-
-        if (request.description() != null) {
-            bookmark.modifyInfo(bookmark.getName(), request.description());
+        String newName =
+            request.bookmarkName() != null ? request.bookmarkName() : bookmark.getName();
+        String newDescription =
+            request.description() != null ? request.description() : bookmark.getDescription();
+        if (request.bookmarkName() != null || request.description() != null) {
+            bookmark.modifyInfo(newName, newDescription);
         }
 
         if (request.placeInfoRequests() != null) {

--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/Bookmark.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/Bookmark.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -35,6 +36,7 @@ public class Bookmark {
     private User user;
 
     @OneToMany(mappedBy = "bookmark", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OrderBy("createdAt ASC")
     private Set<BookmarkPlace> bookmarkPlaces = new LinkedHashSet<>();
 
     @Column

--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/Bookmark.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/Bookmark.java
@@ -1,7 +1,10 @@
 package com.cliptripbe.feature.bookmark.domain.entity;
 
+import static com.cliptripbe.global.response.type.ErrorType.EXISTS_PLACE;
+
 import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.user.domain.entity.User;
+import com.cliptripbe.global.response.exception.CustomException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -77,8 +80,16 @@ public class Bookmark {
     }
 
 
-    public void addBookmarkPlace(BookmarkPlace bookmarkPlace) {
-        this.bookmarkPlaces.add(bookmarkPlace);
+    public void addBookmarkPlace(BookmarkPlace newBookmarkPlace) {
+        Long newPlaceId = newBookmarkPlace.getPlace().getId();
+        boolean exists = bookmarkPlaces.stream()
+            .map(bp -> bp.getPlace().getId())
+            .anyMatch(newPlaceId::equals);
+        if (exists) {
+            throw new CustomException(EXISTS_PLACE);
+        }
+
+        bookmarkPlaces.add(newBookmarkPlace);
     }
 
     public List<Place> getPlaces() {

--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/BookmarkPlace.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/BookmarkPlace.java
@@ -1,6 +1,7 @@
 package com.cliptripbe.feature.bookmark.domain.entity;
 
 import com.cliptripbe.feature.place.domain.entity.Place;
+import com.cliptripbe.global.entity.BaseTimeEntity;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -14,7 +15,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class BookmarkPlace {
+public class BookmarkPlace extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/BookmarkPlace.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/entity/BookmarkPlace.java
@@ -22,11 +22,11 @@ public class BookmarkPlace {
 
     @ManyToOne
     @JoinColumn(name = "bookmark_id")
-    Bookmark bookmark;
+    private Bookmark bookmark;
 
     @ManyToOne
     @JoinColumn(name = "place_id")
-    Place place;
+    private Place place;
 
     @Builder
     public BookmarkPlace(Bookmark bookmark, Place place) {

--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/service/BookmarkMapper.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/service/BookmarkMapper.java
@@ -17,22 +17,6 @@ public class BookmarkMapper {
     }
 
     public static BookmarkInfoResponse mapBookmarkInfoResponse(
-        Bookmark bookmark
-    ) {
-        return BookmarkInfoResponse.builder()
-            .id(bookmark.getId())
-            .name(bookmark.getName())
-            .description(bookmark.getDescription())
-            .placeList(
-                bookmark.getPlaces().stream()
-                    .limit(10)
-                    .map(place -> PlaceListResponse.fromEntity(place, -1))
-                    .toList()
-            )
-            .build();
-    }
-
-    public static BookmarkInfoResponse mapBookmarkInfoResponse(
         Bookmark bookmark,
         List<PlaceListResponse> placeListResponses
     ) {

--- a/src/main/java/com/cliptripbe/feature/bookmark/dto/response/BookmarkInfoResponse.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/dto/response/BookmarkInfoResponse.java
@@ -20,7 +20,7 @@ public record BookmarkInfoResponse(
             .description(bookmark.getDescription())
             .placeList(
                 bookmark.getPlaces().stream()
-                    .limit(30)
+                    .limit(50)
                     .map(place -> PlaceListResponse.fromEntity(place, -1))
                     .toList()
             )

--- a/src/main/java/com/cliptripbe/feature/bookmark/dto/response/BookmarkInfoResponse.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/dto/response/BookmarkInfoResponse.java
@@ -1,5 +1,6 @@
 package com.cliptripbe.feature.bookmark.dto.response;
 
+import com.cliptripbe.feature.bookmark.domain.entity.Bookmark;
 import com.cliptripbe.feature.place.dto.response.PlaceListResponse;
 import java.util.List;
 import lombok.Builder;
@@ -12,4 +13,17 @@ public record BookmarkInfoResponse(
     List<PlaceListResponse> placeList
 ) {
 
+    public static BookmarkInfoResponse from(Bookmark bookmark) {
+        return BookmarkInfoResponse.builder()
+            .id(bookmark.getId())
+            .name(bookmark.getName())
+            .description(bookmark.getDescription())
+            .placeList(
+                bookmark.getPlaces().stream()
+                    .limit(30)
+                    .map(place -> PlaceListResponse.fromEntity(place, -1))
+                    .toList()
+            )
+            .build();
+    }
 }

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -36,7 +36,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 
 @Service
-@Transactional
 @RequiredArgsConstructor
 public class PlaceService {
 
@@ -55,6 +54,7 @@ public class PlaceService {
     private final FileStoragePort fileStoragePort;
     private final PlaceImageProviderPort placeImageProviderPort;
 
+    @Transactional(readOnly = true)
     public PlaceAccessibilityInfoResponse getPlaceAccessibilityInfo(
         PlaceInfoRequest placeInfoRequest
     ) {
@@ -62,6 +62,7 @@ public class PlaceService {
         return PlaceAccessibilityInfoResponse.from(place);
     }
 
+    @Transactional(readOnly = true)
     public PlaceAccessibilityInfoResponse getPlaceInfo(PlaceInfoRequest placeInfoRequest,
         User user) {
         Place place = findOrCreatePlaceByPlaceInfo(placeInfoRequest);
@@ -70,6 +71,7 @@ public class PlaceService {
         return PlaceAccessibilityInfoResponse.of(place, bookmarked);
     }
 
+    @Transactional(readOnly = true)
     public PlaceResponse getPlaceById(Long placeId, User user) {
         Place place = placeFinder.getPlaceById(placeId);
 
@@ -91,7 +93,7 @@ public class PlaceService {
         return PlaceResponse.of(place, bookmarked, placeTranslation);
     }
 
-
+    @Transactional
     public Place findOrCreatePlaceByPlaceInfo(PlaceInfoRequest placeInfoRequest) {
         Place place = placeFinder.getOptionPlaceByPlaceInfo(
             placeInfoRequest.placeName(),
@@ -102,7 +104,7 @@ public class PlaceService {
         return place;
     }
 
-    @Transactional(readOnly = true)
+
     public List<PlaceListResponse> getPlacesByCategory(PlaceSearchByCategoryRequest request) {
         List<PlaceDto> categoryPlaces = placeSearchPort.searchPlacesByCategory(request);
         return categoryPlaces.stream()
@@ -114,7 +116,6 @@ public class PlaceService {
             .toList();
     }
 
-    @Transactional(readOnly = true)
     public List<PlaceListResponse> getPlacesByKeyword(PlaceSearchByKeywordRequest request) {
         List<PlaceDto> keywordPlaces = placeSearchPort.searchPlacesByKeyWord(request);
 
@@ -123,6 +124,7 @@ public class PlaceService {
             .toList();
     }
 
+    @Transactional
     public List<Place> createPlaceAll(List<PlaceDto> placeDtoList) {
         if (placeDtoList.isEmpty()) {
             return Collections.emptyList();
@@ -173,9 +175,8 @@ public class PlaceService {
         return PlaceListResponse.fromList(placesInRange);
     }
 
-    public List<Place> findOrCreatePlacesByPlaceInfos(
-        List<PlaceInfoRequest> placeInfoRequests
-    ) {
+    @Transactional(readOnly = true)
+    public List<Place> findOrCreatePlacesByPlaceInfos(List<PlaceInfoRequest> placeInfoRequests) {
         return placeFinder.findExistingPlaceByAddress(placeInfoRequests);
     }
 }

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -104,7 +104,6 @@ public class PlaceService {
         return place;
     }
 
-
     public List<PlaceListResponse> getPlacesByCategory(PlaceSearchByCategoryRequest request) {
         List<PlaceDto> categoryPlaces = placeSearchPort.searchPlacesByCategory(request);
         return categoryPlaces.stream()

--- a/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleControllerDocs.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleControllerDocs.java
@@ -16,7 +16,7 @@ public interface ScheduleControllerDocs {
     @Operation(summary = "새로운 일정 만들기, 빈 일정입니다.")
     ApiResponse<?> createSchedule(CustomerDetails customerDetails);
 
-    @Operation(summary = "일정 수정하기,put 메서드")
+    @Operation(summary = "일정 수정하기, put 메서드")
     ApiResponse<?> updateSchedule(
         CustomerDetails customerDetails,
         Long scheduleId,

--- a/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
+++ b/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
@@ -31,6 +31,7 @@ public enum ErrorType {
 
     // place
     PLACE_NOT_FOUND(HttpStatus.BAD_REQUEST, "요청한 정보로 place를 찾을 수 없습니다"),
+    EXISTS_PLACE(HttpStatus.BAD_REQUEST, "이미 존재하는 장소 정보입니다."),
 
     // video
     CHATGPT_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "ChatGPT로부터 응답을 받지 못했습니다."),

--- a/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
+++ b/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
@@ -11,8 +11,10 @@ public enum ErrorType {
     //common
     ENUM_RESOURCE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 이넘 값을 찾을 수 없습니다."),
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
-
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "형식에 맞지 않는 요청입니다."),
+    ACCESS_DENIED_EXCEPTION(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
+
     ENTITY_NOT_FOUND(HttpStatus.BAD_REQUEST, "요청한 정보로 엔터티를 찾을 수 없습니다."),
     DUPLICATE_EMAIL_RESOURCE(HttpStatus.CONFLICT, "이미 존재하는 아이디입니다."),
     FAIL_AUTHENTICATION(HttpStatus.UNAUTHORIZED, "아이디와 비밀번호가 틀렸습니다."),
@@ -23,9 +25,12 @@ public enum ErrorType {
     EXPIRED_AUTH_TIME(HttpStatus.UNAUTHORIZED, "이메일 인증 코드가 만료되었습니다."),
     MISMATCH_VERIFIED_CODE(HttpStatus.UNAUTHORIZED, "이메일 인증 코드가 일치하지 않습니다."),
     NOT_VALID_TOKEN(HttpStatus.UNAUTHORIZED, "유효한 토큰이 아닙니다."),
-    INVALID_REQUEST(HttpStatus.BAD_REQUEST, "형식에 맞지 않는 요청입니다."),
+
     DUPLICATE_SEND(HttpStatus.CONFLICT, "인증 코드가 발송되어 있습니다."),
-    ACCESS_DENIED_EXCEPTION(HttpStatus.UNAUTHORIZED, "접근 권한이 없습니다."),
+
+
+    // place
+    PLACE_NOT_FOUND(HttpStatus.BAD_REQUEST, "요청한 정보로 place를 찾을 수 없습니다"),
 
     // video
     CHATGPT_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "ChatGPT로부터 응답을 받지 못했습니다."),


### PR DESCRIPTION
## ✅ 작업 내용
- 북마크 수정 put -> patch로 로직 수정하였습니다.
- 북마크 장소 삭제 api 추가하였습니다
- 북마크 장소 추가시 중복으로 들어가는 부분 수정하였습니다.
- 북마크 상세조회시 장소 리스트 순서가 바뀌는 것 수정하였습니다

## 🤔 고민 했던 부분
- 장소 리스트는 중복 요소를 없애기 위해 Set 자료구조를 사용했습니다.
- set은 순서를 보장하지 않는 자료구조이기 때문에 orderBy를 통해 순서를 보장해주었습니다. 

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 북마크에서 특정 장소를 삭제할 수 있는 기능이 추가되었습니다.
  * 북마크 상세 조회 시 최대 50개의 장소 정보를 반환하도록 개선되었습니다.

* **버그 수정**
  * 북마크에 동일한 장소를 중복 추가할 경우 오류 메시지가 제공됩니다.

* **개선 및 변경**
  * 북마크 관련 엔드포인트 및 메서드 명칭이 보다 명확하게 변경되었습니다.
  * 북마크 수정 시 PATCH 방식이 적용되었습니다.
  * 오류 메시지 및 상태 코드가 보다 세분화되었습니다.
  * 장소 서비스의 트랜잭션 처리 방식이 메서드 단위로 조정되었습니다.

* **스타일**
  * 일부 문서 요약 및 설명의 띄어쓰기가 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->