### PR TITLE
[CTTSK-31]refactor: 카카오맵 장소 검색시 고유 id값 저장

### DIFF
--- a/src/main/java/com/cliptripbe/feature/place/domain/entity/Place.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/entity/Place.java
@@ -105,4 +105,8 @@ public class Place extends BaseTimeEntity {
         }
     }
 
+    public void addKakaoPlaceId(String kakaoPlaceId) {
+        this.kakaoPlaceId = kakaoPlaceId;
+    }
+
 }

--- a/src/main/java/com/cliptripbe/feature/place/domain/entity/Place.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/entity/Place.java
@@ -53,6 +53,9 @@ public class Place extends BaseTimeEntity {
     @Column
     private String imageUrl;
 
+    @Column
+    private String kakaoPlaceId;
+
     @OneToMany(mappedBy = "place", cascade = CascadeType.ALL)
     private Set<PlaceTranslation> placeTranslations = new HashSet<>();
 
@@ -63,7 +66,8 @@ public class Place extends BaseTimeEntity {
         Address address,
         Set<AccessibilityFeature> accessibilityFeatures,
         PlaceType placeType,
-        String imageUrl
+        String imageUrl,
+        String kakaoPlaceId
     ) {
         this.name = name;
         this.phoneNumber = phoneNumber;
@@ -73,6 +77,7 @@ public class Place extends BaseTimeEntity {
             : new HashSet<>();
         this.placeType = placeType;
         this.imageUrl = imageUrl;
+        this.kakaoPlaceId = kakaoPlaceId;
     }
 
     public void addImageUrl(String imageUrl) {

--- a/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceFinder.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceFinder.java
@@ -8,6 +8,7 @@ import com.cliptripbe.global.response.exception.CustomException;
 import com.cliptripbe.global.response.type.ErrorType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -37,11 +38,16 @@ public class PlaceFinder {
         return placeRepository.findByPlaceType(placeType);
     }
 
-    public List<Place> findExistingPlaceByAddressAndName(
+    public List<Place> findExistingPlaceByKakaoPlaceIdOrAddressAndName(
+        List<String> kakaoPlaceIdList,
         List<String> addressList,
         List<String> placeNameList
     ) {
-        return placeRepository.findExistingPlaceByAddressAndName(addressList, placeNameList);
+        return placeRepository.findExistingPlaceByKakaoPlaceIdOrAddressAndName(
+            kakaoPlaceIdList,
+            addressList,
+            placeNameList
+        );
     }
 
     public Optional<Place> findByNameAndRoadAddress(String name, String roadAddress) {

--- a/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceFinder.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceFinder.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,11 +21,16 @@ public class PlaceFinder {
 
     private final PlaceRepository placeRepository;
 
-    public Optional<Place> getOptionPlaceByPlaceInfo(String placeName, String roadAddress) {
-        return placeRepository.findPlaceByPlaceInfo(
-            placeName,
-            roadAddress
-        );
+
+    public Optional<Place> getOptionPlaceByPlaceInfo(
+        String placeName,
+        String roadAddress
+    ) {
+        return placeRepository.findPlaceByPlaceInfo(placeName, roadAddress);
+    }
+
+    public Optional<Place> findByKakaoPlaceId(String kakaoPlaceId) {
+        return placeRepository.findByKakaoPlaceId(kakaoPlaceId);
     }
 
     public Place getPlaceById(Long placeId) {
@@ -60,4 +66,6 @@ public class PlaceFinder {
             .toList();
         return placeRepository.findExistingPlaceByAddress(addresses);
     }
+
+
 }

--- a/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceRegister.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceRegister.java
@@ -25,6 +25,7 @@ public class PlaceRegister {
             .phoneNumber(placeInfoRequest.phoneNumber())
             .address(placeInfoRequest.getAddress())
             .placeType(placeInfoRequest.type())
+            .kakaoPlaceId(placeInfoRequest.kakaoPlaceId())
             .build();
         placeRepository.save(place);
         return place;

--- a/src/main/java/com/cliptripbe/feature/place/dto/PlaceDto.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/PlaceDto.java
@@ -46,6 +46,7 @@ public record PlaceDto(
                 .build()
             )
             .placeType(PlaceType.findByCode(categoryCode))
+            .kakaoPlaceId(kakaoPlaceId)
             .build();
     }
 }

--- a/src/main/java/com/cliptripbe/feature/place/dto/PlaceDto.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/PlaceDto.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 
 @Builder
 public record PlaceDto(
+    String kakaoPlaceId,
     String placeName,
     String address,
     String roadAddress,
@@ -23,6 +24,7 @@ public record PlaceDto(
             roadAddress = document.address_name();
         }
         return PlaceDto.builder()
+            .kakaoPlaceId(document.id())
             .placeName(document.place_name())
             .address(document.address_name())
             .roadAddress(roadAddress)

--- a/src/main/java/com/cliptripbe/feature/place/dto/request/PlaceInfoRequest.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/request/PlaceInfoRequest.java
@@ -12,8 +12,8 @@ public record PlaceInfoRequest(
     String placeName,
     @Pattern(regexp = "^\\d{3}-\\d{3,4}-\\d{4}$", message = "전화번호는 000-0000-0000 형식이어야 합니다.")
     String phoneNumber,
-    PlaceType type
-
+    PlaceType type,
+    String kakaoPlaceId
 ) {
 
     @JsonIgnore

--- a/src/main/java/com/cliptripbe/feature/place/dto/request/PlaceSearchByCategoryRequest.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/request/PlaceSearchByCategoryRequest.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.Max;
 
 public record PlaceSearchByCategoryRequest(
     String categoryCode,
-    String x,
-    String y,
+    String longitude,
+    String latitude,
     @Max(value = 20000, message = "radius는 20000 이하이어야 합니다")
     Integer radius
 ) {

--- a/src/main/java/com/cliptripbe/feature/place/dto/request/PlaceSearchByKeywordRequest.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/request/PlaceSearchByKeywordRequest.java
@@ -4,8 +4,8 @@ import jakarta.validation.constraints.Max;
 
 public record PlaceSearchByKeywordRequest(
     String query,
-    String x,
-    String y,
+    String longitude,
+    String latitude,
     @Max(value = 20000, message = "radius는 20000 이하이어야 합니다")
     Integer radius
 ) {

--- a/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceListResponse.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceListResponse.java
@@ -48,6 +48,10 @@ public record PlaceListResponse(
     }
 
     public static PlaceListResponse fromEntity(Place place, Integer placeOrder) {
+        String kakaoPlaceId = place.getKakaoPlaceId();
+        if (kakaoPlaceId == null) {
+            kakaoPlaceId = "-1";
+        }
         return PlaceListResponse.builder()
             .placeId(place.getId())
             .placeName(place.getName())
@@ -57,6 +61,7 @@ public record PlaceListResponse(
             .longitude(place.getAddress().longitude())
             .latitude(place.getAddress().latitude())
             .placeOrder(placeOrder)
+            .kakaoPlaceId(kakaoPlaceId)
             .build();
     }
 

--- a/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceListResponse.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceListResponse.java
@@ -19,7 +19,8 @@ public record PlaceListResponse(
     PlaceType type,
     double longitude,
     double latitude,
-    Integer placeOrder
+    Integer placeOrder,
+    String kakaoPlaceId
 ) {
 
     public static PlaceListResponse ofDto(PlaceDto placeDto, PlaceType type) {
@@ -30,6 +31,7 @@ public record PlaceListResponse(
             .type(type)
             .longitude(placeDto.longitude())
             .latitude(placeDto.latitude())
+            .kakaoPlaceId(placeDto.kakaoPlaceId())
             .build();
     }
 
@@ -41,6 +43,7 @@ public record PlaceListResponse(
             .type(PlaceType.findByCode(placeDto.categoryCode()))
             .longitude(placeDto.longitude())
             .latitude(placeDto.latitude())
+            .kakaoPlaceId(placeDto.kakaoPlaceId())
             .build();
     }
 

--- a/src/main/java/com/cliptripbe/feature/place/infrastructure/PlaceRepository.java
+++ b/src/main/java/com/cliptripbe/feature/place/infrastructure/PlaceRepository.java
@@ -5,13 +5,18 @@ import com.cliptripbe.feature.place.domain.type.PlaceType;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.antlr.v4.runtime.atn.SemanticContext.AND;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
 
-    @Query("SELECT p FROM Place p WHERE p.name = :name AND p.address.roadAddress = :roadAddress")
+    @Query("""
+        SELECT p 
+          FROM Place p 
+         WHERE p.name = :name AND p.address.roadAddress = :roadAddress
+        """)
     Optional<Place> findPlaceByPlaceInfo(
         @Param("name") String name,
         @Param("roadAddress") String roadAddress
@@ -40,4 +45,5 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     Optional<Place> findByNameAndAddressRoadAddress(String name, String roadAddress);
 
+    Optional<Place> findByKakaoPlaceId(String kakaoPlaceId);
 }

--- a/src/main/java/com/cliptripbe/feature/place/infrastructure/PlaceRepository.java
+++ b/src/main/java/com/cliptripbe/feature/place/infrastructure/PlaceRepository.java
@@ -4,6 +4,7 @@ import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.place.domain.type.PlaceType;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -25,10 +26,11 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
     @Query("""
         SELECT p
           FROM Place p
-         WHERE p.address.roadAddress IN :addressList
-           AND p.name                IN :placeNameList
+         WHERE p.kakaoPlaceId IN :kakaoPlaceIdList
+            OR (p.address.roadAddress IN :addressList AND p.name IN :placeNameList)
         """)
-    List<Place> findExistingPlaceByAddressAndName(
+    List<Place> findExistingPlaceByKakaoPlaceIdOrAddressAndName(
+        @Param("kakaoPlaceIdList") List<String> kakaoPlaceIdList,
         @Param("addressList") List<String> addressList,
         @Param("placeNameList") List<String> placeNameList
     );

--- a/src/main/java/com/cliptripbe/feature/video/application/VideoPlaceExtractFacade.java
+++ b/src/main/java/com/cliptripbe/feature/video/application/VideoPlaceExtractFacade.java
@@ -39,7 +39,6 @@ public class VideoPlaceExtractFacade {
         CaptionResponse caption = videoContentExtractPort.getCaptions(request.youtubeUrl());
 
         String requestPlacePrompt = PromptUtils.build(PromptType.PLACE, caption.captions());
-
         String requestSummaryPrompt = PromptUtils.build(PromptType.SUMMARY_KO, caption.captions());
 
         String gptPlaceResponse = aiTextProcessorPort.askPlaceExtraction(requestPlacePrompt);

--- a/src/main/java/com/cliptripbe/infrastructure/adapter/out/kakao/KakaoMapAdapter.java
+++ b/src/main/java/com/cliptripbe/infrastructure/adapter/out/kakao/KakaoMapAdapter.java
@@ -38,8 +38,8 @@ public class KakaoMapAdapter implements PlaceSearchPort {
                 .uri(uri -> uri
                     .path("/v2/local/search/category.json")
                     .queryParam("category_group_code", request.categoryCode())
-                    .queryParam("x", request.x())
-                    .queryParam("y", request.y())
+                    .queryParam("x", request.longitude())
+                    .queryParam("y", request.latitude())
                     .queryParam("radius", request.radius())
                     .build()
                 )
@@ -73,8 +73,8 @@ public class KakaoMapAdapter implements PlaceSearchPort {
                 .uri(uriBuilder -> uriBuilder
                     .path("/v2/local/search/keyword.json")
                     .queryParam("query", request.query())
-                    .queryParam("x", request.x())
-                    .queryParam("y", request.y())
+                    .queryParam("x", request.longitude())
+                    .queryParam("y", request.latitude())
                     .queryParam("radius", request.radius())
                     .build()
                 )


### PR DESCRIPTION
## ✅ 작업 내용
- 유튜브에서 장소 추출시 
- 북마크에서 장소 저장시
- 북마크 update시 장소 id 저장하였습니다
- 카테고리, 키워드 검색 시 request 칼럼 네이밍 수정했습니다
- 장소 검색시 카카오맵 id 포함하여 응답합니다

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.