### PR TITLE
[CTTSK-39] refactor: bookmark 물품보관소 수정

### DIFF
--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/service/BookmarkFinder.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/service/BookmarkFinder.java
@@ -8,6 +8,7 @@ import com.cliptripbe.feature.bookmark.infrastructure.projection.BookmarkMapping
 import com.cliptripbe.feature.bookmark.infrastructure.projection.PlaceBookmarkMapping;
 import com.cliptripbe.global.response.exception.CustomException;
 import com.cliptripbe.global.response.type.ErrorType;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -48,7 +49,11 @@ public class BookmarkFinder {
                 userId, kakaoPlaceIdList).stream()
             .collect(Collectors.groupingBy(
                 BookmarkMapping::getKakaoPlaceId,
-                Collectors.mapping(BookmarkMapping::getBookmarkId, Collectors.toList())
+                Collectors.mapping(BookmarkMapping::getBookmarkId,
+                    Collectors.collectingAndThen(
+                        Collectors.toSet(),
+                        ArrayList::new
+                    ))
             ));
     }
 
@@ -62,7 +67,11 @@ public class BookmarkFinder {
         return mappings.stream()
             .collect(Collectors.groupingBy(
                 PlaceBookmarkMapping::getPlaceId,
-                Collectors.mapping(PlaceBookmarkMapping::getBookmarkId, Collectors.toList())
+                Collectors.mapping(PlaceBookmarkMapping::getBookmarkId,
+                    Collectors.collectingAndThen(
+                        Collectors.toSet(),
+                        ArrayList::new
+                    ))
             ));
     }
 }

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -40,6 +40,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 
@@ -56,6 +57,7 @@ public class PlaceService {
     private final PlaceRegister placeRegister;
     private final PlaceFinder placeFinder;
     private final PlaceClassifier placeClassifier;
+    private final PlaceTransactionService placeTransactionService;
     private final PlaceRepository placeRepository;
     private final PlaceTranslationService placeTranslationService;
     private final PlaceTranslationFinder placeTranslationFinder;
@@ -133,10 +135,7 @@ public class PlaceService {
             return place;
 
         } catch (DataIntegrityViolationException e) {
-            Place place = placeRepository.findByKakaoPlaceId(kakaoPlaceId)
-                .orElseThrow(() -> new CustomException(FAIL_CREATE_PLACE_ENTITY));
-            placeTranslationService.registerPlace(place);
-            return place;
+            return placeTransactionService.handleDuplicateKakaoPlaceId(kakaoPlaceId);
         }
     }
 
@@ -324,4 +323,6 @@ public class PlaceService {
     public List<Place> findOrCreatePlacesByPlaceInfos(List<PlaceInfoRequest> placeInfoRequests) {
         return placeFinder.findExistingPlaceByAddress(placeInfoRequests);
     }
+
+
 }

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceTransactionService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceTransactionService.java
@@ -1,0 +1,28 @@
+package com.cliptripbe.feature.place.application;
+
+import static com.cliptripbe.global.response.type.ErrorType.FAIL_CREATE_PLACE_ENTITY;
+
+import com.cliptripbe.feature.place.domain.entity.Place;
+import com.cliptripbe.feature.place.infrastructure.PlaceRepository;
+import com.cliptripbe.global.response.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceTransactionService {
+
+    private final PlaceRepository placeRepository;
+    private final PlaceTranslationService placeTranslationService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Place handleDuplicateKakaoPlaceId(String kakaoPlaceId) {
+        // TODO : 여기서도 번역??????? 담당해야됨 리트라이하는 부분임
+        Place place = placeRepository.findByKakaoPlaceId(kakaoPlaceId)
+            .orElseThrow(() -> new CustomException(FAIL_CREATE_PLACE_ENTITY));
+        placeTranslationService.registerPlace(place);
+        return place;
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceRegister.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceRegister.java
@@ -1,14 +1,16 @@
 package com.cliptripbe.feature.place.domain.service;
 
+
 import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.place.dto.request.PlaceInfoRequest;
 import com.cliptripbe.feature.place.infrastructure.PlaceRepository;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Component
+@Service
 @Transactional
 @RequiredArgsConstructor
 public class PlaceRegister {
@@ -31,4 +33,6 @@ public class PlaceRegister {
         placeRepository.saveAndFlush(place);
         return place;
     }
+
+
 }

--- a/src/main/java/com/cliptripbe/infrastructure/adapter/out/kakao/KakaoMapAdapter.java
+++ b/src/main/java/com/cliptripbe/infrastructure/adapter/out/kakao/KakaoMapAdapter.java
@@ -105,6 +105,11 @@ public class KakaoMapAdapter implements PlaceSearchPort {
                     .retrieve()
                     .body(KakaoMapResponse.class);
 
+                if (response == null || response.documents() == null || response.documents()
+                    .isEmpty()) {
+                    break;
+                }
+
                 List<PlaceDto> places = Optional.ofNullable(response)
                     .orElseThrow(() -> new CustomException(KAKAO_MAP_NO_RESPONSE))
                     .documents()
@@ -112,6 +117,10 @@ public class KakaoMapAdapter implements PlaceSearchPort {
                     .map(PlaceDto::from)
                     .toList();
                 allPlaces.addAll(places);
+
+                if (response.meta().is_end()) {
+                    break;
+                }
             }
             long elapsed = System.currentTimeMillis() - start;
             log.info("[{}] 개별 호출 레이턴시: {} ms", request.query(), elapsed);


### PR DESCRIPTION
## ✅ 작업 내용
- 장소 검색시 장소가 3개 중복으로 뜨는 거 수정했습니다.
- 북마크 상세조회, 물품보관소 검색 시 북마크 id 중복으로 뜨는 거 수정했습니다.
- select 동시성 문제에서 재시도 하는 부분 트랜잭션 분리하였습니다. 

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 장소 키워드 검색 시, 카카오 API 응답이 비어있거나 마지막 페이지일 때 검색이 중단되도록 개선하여 오류를 방지했습니다.
  * 북마크 ID 목록에서 중복이 제거되어, 중복 없는 북마크 ID만 반환됩니다.

* **신규 기능**
  * 중복된 카카오 장소 ID 처리 및 번역 등록을 위한 별도의 트랜잭션 서비스가 추가되었습니다.

* **리팩터**
  * PlaceRegister 클래스의 빈 타입이 @Component에서 @Service로 변경되었습니다.
  * 중복된 카카오 장소 ID 예외 처리 로직이 별도의 서비스로 위임되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->