### PR TITLE
[CTTSK-27] feat: kakaoPlaceId로 장소 상세 조회 구현

### DIFF
--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/service/BookmarkFinder.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/service/BookmarkFinder.java
@@ -74,4 +74,8 @@ public class BookmarkFinder {
                     ))
             ));
     }
+
+    public List<Long> findBookmarkIdsByPlaceId(Long userId, Long placeId) {
+        return bookmarkRepository.findPlaceIdsByUserAndPlaceId(userId, placeId);
+    }
 }

--- a/src/main/java/com/cliptripbe/feature/bookmark/infrastructure/BookmarkRepository.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/infrastructure/BookmarkRepository.java
@@ -74,7 +74,7 @@ BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Long> findPlaceIdsByBookmarkId(@Param("bookmarkId") Long bookmarkId);
 
     @Query("""
-            SELECT p.id
+            SELECT b.id
             FROM BookmarkPlace bp
             JOIN bp.place p
             JOIN bp.bookmark b

--- a/src/main/java/com/cliptripbe/feature/bookmark/infrastructure/BookmarkRepository.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/infrastructure/BookmarkRepository.java
@@ -20,12 +20,6 @@ BookmarkRepository extends JpaRepository<Bookmark, Long> {
     List<Bookmark> findDefaultBookmarksExcludingName(
         @Param("excludedBookmarkName") String excludedBookmarkName);
 
-    @Query("""
-            SELECT COUNT(bp) > 0
-            FROM BookmarkPlace bp
-            WHERE bp.bookmark.user.id = :userId AND bp.place.id = :placeId
-        """)
-    boolean isPlaceBookmarkedByUser(@Param("userId") Long userId, @Param("placeId") Long placeId);
 
     @Query("SELECT DISTINCT b FROM Bookmark b " +
         "LEFT JOIN FETCH b.bookmarkPlaces bp " +
@@ -78,5 +72,18 @@ BookmarkRepository extends JpaRepository<Bookmark, Long> {
         order by bp.id
     """)
     List<Long> findPlaceIdsByBookmarkId(@Param("bookmarkId") Long bookmarkId);
+
+    @Query("""
+            SELECT p.id
+            FROM BookmarkPlace bp
+            JOIN bp.place p
+            JOIN bp.bookmark b
+            WHERE p.id = :placeId
+              AND b.user.id = :userId
+        """)
+    List<Long> findPlaceIdsByUserAndPlaceId(
+        @Param("placeId") Long placeId,
+        @Param("userId") Long userId
+    );
 }
 

--- a/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
@@ -3,7 +3,9 @@ package com.cliptripbe.feature.place.api;
 import static com.cliptripbe.global.constant.Constant.API_VERSION;
 
 import com.cliptripbe.feature.place.application.PlaceService;
+import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.place.dto.request.LuggageStorageRequest;
+import com.cliptripbe.feature.place.dto.request.PlaceInfoRequest;
 import com.cliptripbe.feature.place.dto.request.PlaceSearchByCategoryRequest;
 import com.cliptripbe.feature.place.dto.request.PlaceSearchByKeywordRequest;
 import com.cliptripbe.feature.place.dto.response.PlaceListResponse;
@@ -18,6 +20,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -35,6 +39,18 @@ public class PlaceController implements PlaceControllerDocs {
     ) {
         PlaceResponse place = placeService.getPlaceById(placeId, customerDetails.getUser());
         return ApiResponse.success(SuccessType.OK, place);
+    }
+
+
+    @Override
+    @PostMapping("/by-external-id")
+    public ApiResponse<PlaceResponse> getPlaceByKakaoPlaceId(
+        @RequestBody PlaceInfoRequest request,
+        @AuthenticationPrincipal CustomerDetails customerDetails
+    ) {
+        PlaceResponse response = placeService.findOrCreateByKakaoPlaceId(
+            request, customerDetails.getUser());
+        return ApiResponse.success(SuccessType.OK, response);
     }
 
     @GetMapping("/category")

--- a/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
@@ -44,7 +44,7 @@ public class PlaceController implements PlaceControllerDocs {
 
     @Override
     @PostMapping("/by-external-id")
-    public ApiResponse<PlaceResponse> getPlaceByKakaoPlaceId(
+    public ApiResponse<PlaceResponse> findOrCreatePlaceByKakaoPlaceId(
         @RequestBody PlaceInfoRequest request,
         @AuthenticationPrincipal CustomerDetails customerDetails
     ) {

--- a/src/main/java/com/cliptripbe/feature/place/api/PlaceControllerDocs.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/PlaceControllerDocs.java
@@ -26,7 +26,7 @@ public interface PlaceControllerDocs {
     @Operation(
         summary = "장소카드 상세조회 by kakaoPlaceId, 로그인 필요",
         description = "장소 카드 상세 조회입니다 by kakaoPlaceId. 키워드, 카테고리 검색을 통해 장소 카드로 넘어갈 때 사용됩니다.")
-    ApiResponse<PlaceResponse> getPlaceByKakaoPlaceId(
+    ApiResponse<PlaceResponse> findOrCreatePlaceByKakaoPlaceId(
         PlaceInfoRequest request,
         CustomerDetails customerDetails
     );

--- a/src/main/java/com/cliptripbe/feature/place/api/PlaceControllerDocs.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/PlaceControllerDocs.java
@@ -1,6 +1,7 @@
 package com.cliptripbe.feature.place.api;
 
 import com.cliptripbe.feature.place.dto.request.LuggageStorageRequest;
+import com.cliptripbe.feature.place.dto.request.PlaceInfoRequest;
 import com.cliptripbe.feature.place.dto.request.PlaceSearchByCategoryRequest;
 import com.cliptripbe.feature.place.dto.request.PlaceSearchByKeywordRequest;
 import com.cliptripbe.feature.place.dto.response.PlaceListResponse;
@@ -15,10 +16,18 @@ import java.util.List;
 public interface PlaceControllerDocs {
 
     @Operation(
-        summary = "장소카드 상세조회, 로그인 필요",
-        description = "장소 카드 상세 조회입니다. 유저가 해당 장소에 북마크를 했는지 여부를 알려줍니다.")
+        summary = "장소카드 상세조회 by placeId, 로그인 필요",
+        description = "장소 카드 상세 조회입니다 by placeId. 물품보관소, 북마크, 일정에서 장소 카드로 넘어갈 때 사용됩니다.")
     ApiResponse<PlaceResponse> getPlaceById(
         Long placeId,
+        CustomerDetails customerDetails
+    );
+
+    @Operation(
+        summary = "장소카드 상세조회 by kakaoPlaceId, 로그인 필요",
+        description = "장소 카드 상세 조회입니다 by kakaoPlaceId. 키워드, 카테고리 검색을 통해 장소 카드로 넘어갈 때 사용됩니다.")
+    ApiResponse<PlaceResponse> getPlaceByKakaoPlaceId(
+        PlaceInfoRequest request,
         CustomerDetails customerDetails
     );
 

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceImageService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceImageService.java
@@ -1,0 +1,24 @@
+package com.cliptripbe.feature.place.application;
+
+import com.cliptripbe.feature.place.domain.entity.Place;
+import com.cliptripbe.infrastructure.port.google.PlaceImageProviderPort;
+import com.cliptripbe.infrastructure.port.s3.FileStoragePort;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PlaceImageService {
+
+    private static final String S3_PLACE_PREFIX = "place/";
+
+    private final FileStoragePort fileStoragePort;
+    private final PlaceImageProviderPort placeImageProviderPort;
+
+    public void savePlaceImage(Place place) {
+        String searchKeyWord = place.getName() + " " + place.getAddress().roadAddress();
+        byte[] imageBytes = placeImageProviderPort.getPhotoByAddress(searchKeyWord);
+        String imageUrl = fileStoragePort.upload(S3_PLACE_PREFIX, imageBytes);
+        place.addImageUrl(imageUrl);
+    }
+}

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -87,7 +87,7 @@ public class PlaceService {
 
         PlaceTranslation placeTranslation = placeTranslationFinder.getByPlaceAndLanguage(place,
             user.getLanguage());
-        return PlaceResponse.of(place, bookmarked, placeTranslation);
+        return PlaceResponse.ofTranslation(place, bookmarked, placeTranslation);
     }
 
 //    @Transactional

--- a/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceResponse.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceResponse.java
@@ -4,6 +4,7 @@ import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.place.domain.entity.PlaceTranslation;
 import com.cliptripbe.feature.place.domain.type.AccessibilityFeature;
 import com.cliptripbe.feature.place.domain.type.PlaceType;
+import java.util.List;
 import java.util.Set;
 import lombok.Builder;
 
@@ -13,32 +14,34 @@ public record PlaceResponse(
     String placeName,
     String roadAddress,
     String phone,
-    PlaceType placeType,
+    PlaceType type,
     double longitude,
     double latitude,
     Set<AccessibilityFeature> accessibilityFeatures,
-    Boolean bookmarked,
-    String imageUrl
+    String imageUrl,
+    List<Long> bookmarkedIdList,
+    String kakaoPlaceId
 ) {
 
-    public static PlaceResponse of(Place place, Boolean bookmarked) {
+    public static PlaceResponse of(Place place, List<Long> bookmarkedIdList) {
         return PlaceResponse.builder()
             .placeId(place.getId())
             .placeName(place.getName())
             .roadAddress(place.getAddress().roadAddress())
             .phone(place.getPhoneNumber())
-            .placeType(place.getPlaceType())
+            .type(place.getPlaceType())
             .longitude(place.getAddress().longitude())
             .latitude(place.getAddress().latitude())
             .accessibilityFeatures(place.getAccessibilityFeatures())
-            .bookmarked(bookmarked)
             .imageUrl(place.getImageUrl())
+            .bookmarkedIdList(bookmarkedIdList)
+            .kakaoPlaceId(place.getKakaoPlaceId())
             .build();
     }
 
     public static PlaceResponse ofTranslation(
         Place place,
-        Boolean bookmarked,
+        List<Long> bookmarkedIdList,
         PlaceTranslation placeTranslation
     ) {
         return PlaceResponse.builder()
@@ -46,12 +49,13 @@ public record PlaceResponse(
             .placeName(placeTranslation.getName())
             .roadAddress(placeTranslation.getRoadAddress())
             .phone(place.getPhoneNumber())
-            .placeType(place.getPlaceType())
+            .type(place.getPlaceType())
             .longitude(place.getAddress().longitude())
             .latitude(place.getAddress().latitude())
             .accessibilityFeatures(place.getAccessibilityFeatures())
-            .bookmarked(bookmarked)
             .imageUrl(place.getImageUrl())
+            .bookmarkedIdList(bookmarkedIdList)
+            .kakaoPlaceId(place.getKakaoPlaceId())
             .build();
     }
 }

--- a/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceResponse.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceResponse.java
@@ -3,6 +3,7 @@ package com.cliptripbe.feature.place.dto.response;
 import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.place.domain.entity.PlaceTranslation;
 import com.cliptripbe.feature.place.domain.type.AccessibilityFeature;
+import com.cliptripbe.feature.place.domain.type.PlaceType;
 import java.util.Set;
 import lombok.Builder;
 
@@ -12,7 +13,7 @@ public record PlaceResponse(
     String placeName,
     String roadAddress,
     String phone,
-    String type,
+    PlaceType placeType,
     double longitude,
     double latitude,
     Set<AccessibilityFeature> accessibilityFeatures,
@@ -26,7 +27,7 @@ public record PlaceResponse(
             .placeName(place.getName())
             .roadAddress(place.getAddress().roadAddress())
             .phone(place.getPhoneNumber())
-            .type(place.getPlaceType().getKorName())
+            .placeType(place.getPlaceType())
             .longitude(place.getAddress().longitude())
             .latitude(place.getAddress().latitude())
             .accessibilityFeatures(place.getAccessibilityFeatures())
@@ -35,7 +36,7 @@ public record PlaceResponse(
             .build();
     }
 
-    public static PlaceResponse of(
+    public static PlaceResponse ofTranslation(
         Place place,
         Boolean bookmarked,
         PlaceTranslation placeTranslation
@@ -45,7 +46,7 @@ public record PlaceResponse(
             .placeName(placeTranslation.getName())
             .roadAddress(placeTranslation.getRoadAddress())
             .phone(place.getPhoneNumber())
-            .type(place.getPlaceType().getEngName())
+            .placeType(place.getPlaceType())
             .longitude(place.getAddress().longitude())
             .latitude(place.getAddress().latitude())
             .accessibilityFeatures(place.getAccessibilityFeatures())


### PR DESCRIPTION
## ✅ 작업 내용
- 키워드, 카테고리 검색에서 kakaoPlaceId로 장소카드 조회 할 수 있도록 api 구현하였습니다

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 외부(Kakao) ID로 장소 조회/생성 엔드포인트 추가: POST /places/by-external-id
  - 로그인 사용자 기준 특정 장소의 북마크 ID 목록 반환 지원
  - 장소 이미지가 없을 경우 자동 검색·업로드로 이미지 보강

- Refactor
  - 장소 응답 스키마 변경: type → PlaceType, bookmarked(불리언) 제거, bookmarkedIdList·kakaoPlaceId 추가
  - 서비스 내부 이미지·북마크 처리 흐름 개선 및 트랜잭션 적용

- Documentation
  - 신규 엔드포인트 및 기존 place 조회 동작 설명 업데이트
<!-- end of auto-generated comment: release notes by coderabbit.ai -->