### PR TITLE
[CTTSK-47] refactor: 장소 상세조회시 장소추출 수정

### DIFF
--- a/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
@@ -41,7 +41,6 @@ public class PlaceController implements PlaceControllerDocs {
         return ApiResponse.success(SuccessType.OK, place);
     }
 
-
     @Override
     @PostMapping("/by-external-id")
     public ApiResponse<PlaceResponse> findOrCreatePlaceByKakaoPlaceId(

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceImageService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceImageService.java
@@ -5,6 +5,7 @@ import com.cliptripbe.infrastructure.port.google.PlaceImageProviderPort;
 import com.cliptripbe.infrastructure.port.s3.FileStoragePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +16,7 @@ public class PlaceImageService {
     private final FileStoragePort fileStoragePort;
     private final PlaceImageProviderPort placeImageProviderPort;
 
+    @Transactional
     public void savePlaceImage(Place place) {
         String searchKeyWord = place.getName() + " " + place.getAddress().roadAddress();
         byte[] imageBytes = placeImageProviderPort.getPhotoByAddress(searchKeyWord);

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -174,17 +174,20 @@ public class PlaceService {
         Language userLanguage = user.getLanguage();
 
         if (userLanguage == Language.KOREAN) {
-            return placeListResponseAssembler.createPlaceListResponseForKorean(placeDtoList, bookmarkIdsMap);
+            return placeListResponseAssembler.createPlaceListResponseForKorean(placeDtoList,
+                bookmarkIdsMap);
         }
 
-        List<TranslatedPlaceAddress> translatedPlaces = placeTranslationService.getTranslatedPlaces(userLanguage,
+        List<TranslatedPlaceAddress> translatedPlaces = placeTranslationService.getTranslatedPlaces(
+            userLanguage,
             placeDtoList);
         Map<String, PlaceDto> placeDtoMap = placeDtoList.stream()
             .collect(Collectors.toMap(
                 dto -> dto.placeName() + dto.roadAddress(),
                 Function.identity()
             ));
-        return placeListResponseAssembler.createPlaceListResponseForForeign(placeDtoMap, translatedPlaces,
+        return placeListResponseAssembler.createPlaceListResponseForForeign(placeDtoMap,
+            translatedPlaces,
             bookmarkIdsMap, userLanguage);
     }
 
@@ -205,17 +208,20 @@ public class PlaceService {
         Language userLanguage = user.getLanguage();
 
         if (userLanguage == Language.KOREAN) {
-            return placeListResponseAssembler.createPlaceListResponseForKorean(keywordPlaces, bookmarkIdsMap);
+            return placeListResponseAssembler.createPlaceListResponseForKorean(keywordPlaces,
+                bookmarkIdsMap);
         }
 
-        List<TranslatedPlaceAddress> translatedPlaces = placeTranslationService.getTranslatedPlaces(userLanguage,
+        List<TranslatedPlaceAddress> translatedPlaces = placeTranslationService.getTranslatedPlaces(
+            userLanguage,
             keywordPlaces);
         Map<String, PlaceDto> placeDtoMap = keywordPlaces.stream()
             .collect(Collectors.toMap(
                 dto -> dto.placeName() + dto.roadAddress(),
                 Function.identity()
             ));
-        return placeListResponseAssembler.createPlaceListResponseForForeign(placeDtoMap, translatedPlaces,
+        return placeListResponseAssembler.createPlaceListResponseForForeign(placeDtoMap,
+            translatedPlaces,
             bookmarkIdsMap, userLanguage);
     }
 
@@ -334,11 +340,13 @@ public class PlaceService {
     }
 
     @Transactional
-    public Map<Long, TranslationInfoDto> getTranslationsForPlaces(List<Place> places, Language language) {
+    public Map<Long, TranslationInfoDto> getTranslationsForPlaces(List<Place> places,
+        Language language) {
         List<Long> placeIds = places.stream()
             .map(Place::getId)
             .toList();
-        List<PlaceTranslation> translations = placeTranslationService.findByPlaceIdInAndLanguage(placeIds, language);
+        List<PlaceTranslation> translations = placeTranslationService.findByPlaceIdInAndLanguage(
+            placeIds, language);
         return translations.stream()
             .collect(Collectors.toMap(
                 translation -> translation.getPlace().getId(),


### PR DESCRIPTION
## ✅ 작업 내용
- 구글 지도 외부 호출시 http 상태 분기를 상세로 나눴습니다.
- 트랜잭션 전파 범위를 늘려 더티체크로 이미지를 추가합니다

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.