### PR TITLE
[CTTST-28] refactor: schedule 수정 put에서 patch로 변경

### DIFF
--- a/src/main/java/com/cliptripbe/feature/bookmark/domain/service/BookmarkFinder.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/domain/service/BookmarkFinder.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
@@ -75,7 +76,7 @@ public class BookmarkFinder {
             ));
     }
 
-    public List<Long> findBookmarkIdsByPlaceId(Long userId, Long placeId) {
-        return bookmarkRepository.findPlaceIdsByUserAndPlaceId(userId, placeId);
+    public List<Long> findBookmarkIdsByUserIdAndPlaceId(Long userId, Long placeId) {
+        return bookmarkRepository.findBookmarkIdsByUserIdAndPlaceId(userId, placeId);
     }
 }

--- a/src/main/java/com/cliptripbe/feature/bookmark/infrastructure/BookmarkRepository.java
+++ b/src/main/java/com/cliptripbe/feature/bookmark/infrastructure/BookmarkRepository.java
@@ -78,12 +78,13 @@ BookmarkRepository extends JpaRepository<Bookmark, Long> {
             FROM BookmarkPlace bp
             JOIN bp.place p
             JOIN bp.bookmark b
-            WHERE p.id = :placeId
-              AND b.user.id = :userId
+            WHERE b.user.id = :userId
+              AND p.id = :placeId
+                      
         """)
-    List<Long> findPlaceIdsByUserAndPlaceId(
-        @Param("placeId") Long placeId,
-        @Param("userId") Long userId
+    List<Long> findBookmarkIdsByUserIdAndPlaceId(
+        @Param("userId") Long userId,
+        @Param("placeId") Long placeId
     );
 }
 

--- a/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
+++ b/src/main/java/com/cliptripbe/feature/place/api/PlaceController.java
@@ -3,7 +3,6 @@ package com.cliptripbe.feature.place.api;
 import static com.cliptripbe.global.constant.Constant.API_VERSION;
 
 import com.cliptripbe.feature.place.application.PlaceService;
-import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.place.dto.request.LuggageStorageRequest;
 import com.cliptripbe.feature.place.dto.request.PlaceInfoRequest;
 import com.cliptripbe.feature.place.dto.request.PlaceSearchByCategoryRequest;

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceImageService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceImageService.java
@@ -16,7 +16,7 @@ public class PlaceImageService {
     private final FileStoragePort fileStoragePort;
     private final PlaceImageProviderPort placeImageProviderPort;
 
-    @Transactional
+
     public void savePlaceImage(Place place) {
         String searchKeyWord = place.getName() + " " + place.getAddress().roadAddress();
         byte[] imageBytes = placeImageProviderPort.getPhotoByAddress(searchKeyWord);

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -55,6 +55,7 @@ public class PlaceService {
     private final PlaceRegister placeRegister;
     private final PlaceFinder placeFinder;
     private final PlaceClassifier placeClassifier;
+    private final PlaceListResponseAssembler placeListResponseAssembler;
     private final PlaceRepository placeRepository;
     private final PlaceTranslationService placeTranslationService;
     private final PlaceTranslationFinder placeTranslationFinder;
@@ -63,9 +64,7 @@ public class PlaceService {
 
     private final EntityManager entityManager;
 
-    private final PlaceListResponseAssembler placeListResponseAssembler;
 
-    @Transactional(readOnly = true)
     public PlaceResponse getPlaceById(Long placeId, User user) {
         Place place = placeFinder.getPlaceById(placeId);
 
@@ -73,17 +72,17 @@ public class PlaceService {
             placeImageService.savePlaceImage(place);
         }
 
-        List<Long> bookmarkIds = bookmarkFinder.findBookmarkIdsByPlaceId(
+        List<Long> bookmarkedIdList = bookmarkFinder.findBookmarkIdsByUserIdAndPlaceId(
             user.getId(), place.getId());
 
         // TODO : 여기도 번역 적용해주세요.
         if (user.getLanguage() == Language.KOREAN) {
-            return PlaceResponse.of(place, bookmarkIds);
+            return PlaceResponse.of(place, bookmarkedIdList);
         }
 
         PlaceTranslation placeTranslation = placeTranslationFinder.getByPlaceAndLanguage(place,
             user.getLanguage());
-        return PlaceResponse.ofTranslation(place, bookmarkIds, placeTranslation);
+        return PlaceResponse.ofTranslation(place, bookmarkedIdList, placeTranslation);
     }
 
     public PlaceResponse findOrCreateByKakaoPlaceId(PlaceInfoRequest request, User user) {
@@ -92,12 +91,12 @@ public class PlaceService {
         if (place.getImageUrl() == null || place.getImageUrl().isEmpty()) {
             placeImageService.savePlaceImage(place);
         }
-        List<Long> bookmarkIds = bookmarkFinder.findBookmarkIdsByPlaceId(
+        List<Long> bookmarkedIdList = bookmarkFinder.findBookmarkIdsByUserIdAndPlaceId(
             user.getId(), place.getId());
 
         // TODO : 여기도 번역 적용해주세요.
         if (user.getLanguage() == Language.KOREAN) {
-            return PlaceResponse.of(place, bookmarkIds);
+            return PlaceResponse.of(place, bookmarkedIdList);
         }
         return null;
     }

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -351,7 +351,9 @@ public class PlaceService {
             .collect(Collectors.toMap(Place::getKakaoPlaceId, Function.identity()));
 
         Map<String, Place> placeByAddressName = allPlaces.stream()
-            .filter(p -> p.getAddress().roadAddress() != null && p.getName() != null)
+            .filter(p -> p.getAddress() != null
+                && p.getAddress().roadAddress() != null
+                && p.getName() != null)
             .collect(Collectors.toMap(
                 p -> p.getName() + "|" + p.getAddress().roadAddress(),
                 Function.identity()

--- a/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceFinder.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/service/PlaceFinder.java
@@ -8,9 +8,7 @@ import com.cliptripbe.global.response.exception.CustomException;
 import com.cliptripbe.global.response.type.ErrorType;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.apache.commons.lang3.BooleanUtils;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -59,13 +57,4 @@ public class PlaceFinder {
     public Optional<Place> findByNameAndRoadAddress(String name, String roadAddress) {
         return placeRepository.findByNameAndAddressRoadAddress(name, roadAddress);
     }
-
-    public List<Place> findExistingPlaceByAddress(List<PlaceInfoRequest> placeInfoRequests) {
-        List<String> addresses = placeInfoRequests.stream()
-            .map(PlaceInfoRequest::roadAddress)
-            .toList();
-        return placeRepository.findExistingPlaceByAddress(addresses);
-    }
-
-
 }

--- a/src/main/java/com/cliptripbe/feature/place/dto/PlaceDto.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/PlaceDto.java
@@ -3,6 +3,7 @@ package com.cliptripbe.feature.place.dto;
 import com.cliptripbe.feature.place.domain.entity.Place;
 import com.cliptripbe.feature.place.domain.type.PlaceType;
 import com.cliptripbe.feature.place.domain.vo.Address;
+import com.cliptripbe.feature.place.dto.request.PlaceInfoRequest;
 import com.cliptripbe.infrastructure.adapter.out.kakao.dto.KakaoMapResponse;
 import lombok.Builder;
 
@@ -47,6 +48,19 @@ public record PlaceDto(
             )
             .placeType(PlaceType.findByCode(categoryCode))
             .kakaoPlaceId(kakaoPlaceId)
+            .build();
+    }
+
+    public static PlaceDto fromDto(PlaceInfoRequest request) {
+        return PlaceDto.builder()
+            .kakaoPlaceId(request.kakaoPlaceId())
+            .placeName(request.placeName())
+            .address(request.roadAddress())
+            .roadAddress(request.roadAddress())
+            .phone(request.phone())
+            .categoryCode(request.type() != null ? request.type().getCode() : null)
+            .longitude(request.longitude())
+            .latitude(request.latitude())
             .build();
     }
 }

--- a/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleController.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleController.java
@@ -39,18 +39,18 @@ public class ScheduleController implements ScheduleControllerDocs {
 
     @Override
     @PutMapping("/{scheduleId}")
-    public ApiResponse<?> updateSchedule(
+    public ApiResponse<Long> updateSchedule(
         @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable Long scheduleId,
         @RequestBody UpdateScheduleRequest updateSchedule
     ) {
         scheduleService.updateSchedule(customerDetails.getUser(), scheduleId, updateSchedule);
-        return ApiResponse.success(SuccessType.OK);
+        return ApiResponse.success(SuccessType.OK, scheduleId);
     }
 
     @Override
     @GetMapping()
-    public ApiResponse<?> getUserScheduleList(
+    public ApiResponse<List<ScheduleListResponse>> getUserScheduleList(
         @AuthenticationPrincipal CustomerDetails customerDetails
     ) {
         List<ScheduleListResponse> list = scheduleService.getUserScheduleList(
@@ -60,7 +60,7 @@ public class ScheduleController implements ScheduleControllerDocs {
 
     @Override
     @GetMapping("/{scheduleId}")
-    public ApiResponse<?> getUserSchedule(
+    public ApiResponse<ScheduleResponse> getUserSchedule(
         @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable(value = "scheduleId") Long scheduleId
     ) {
@@ -72,7 +72,7 @@ public class ScheduleController implements ScheduleControllerDocs {
 
     @Override
     @DeleteMapping("/{scheduleId}")
-    public ApiResponse<?> deleteUserSchedule(
+    public ApiResponse<Long> deleteUserSchedule(
         @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable(value = "scheduleId") Long scheduleId) {
         scheduleService.deleteSchedule(customerDetails.getUser(), scheduleId);

--- a/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleController.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleController.java
@@ -14,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -38,7 +39,7 @@ public class ScheduleController implements ScheduleControllerDocs {
     }
 
     @Override
-    @PutMapping("/{scheduleId}")
+    @PatchMapping("/{scheduleId}")
     public ApiResponse<Long> updateSchedule(
         @AuthenticationPrincipal CustomerDetails customerDetails,
         @PathVariable Long scheduleId,

--- a/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleControllerDocs.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleControllerDocs.java
@@ -1,51 +1,36 @@
 package com.cliptripbe.feature.schedule.api;
 
 import com.cliptripbe.feature.schedule.dto.request.UpdateScheduleRequest;
+import com.cliptripbe.feature.schedule.dto.response.ScheduleListResponse;
+import com.cliptripbe.feature.schedule.dto.response.ScheduleResponse;
 import com.cliptripbe.global.auth.security.CustomerDetails;
 import com.cliptripbe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import java.util.List;
 
 @Tag(name = "스케줄 관련 API, 로그인 필요")
 public interface ScheduleControllerDocs {
-
-//    @Operation(summary = "일정만들기, (장소 리스트를 받으면서 만들기)")
-//    ApiResponse<?> createScheduleByVideo(CustomerDetails customerDetails,
-//        CreateScheduleRequestDto createScheduleRequestDto);
 
     @Operation(summary = "새로운 일정 만들기, 빈 일정입니다.")
     ApiResponse<?> createSchedule(CustomerDetails customerDetails);
 
     @Operation(summary = "일정 수정하기, put 메서드")
-    ApiResponse<?> updateSchedule(
+    ApiResponse<Long> updateSchedule(
         CustomerDetails customerDetails,
         Long scheduleId,
         UpdateScheduleRequest updateSchedule
     );
 
-//    @Operation(summary = "일정안에 있는 장소 삭제, 지울 장소는 리스트로 ")
-//    ApiResponse<?> deleteSchedulePlace(
-//        CustomerDetails customerDetails,
-//        Long scheduleId,
-//        DeleteSchedulePlaceRequestDto deleteSchedulePlaceRequestDto
-//    );
-
     @Operation(summary = "유저 전체 일정 조회하기")
-    ApiResponse<?> getUserScheduleList(CustomerDetails customerDetails);
+    ApiResponse<List<ScheduleListResponse>> getUserScheduleList(CustomerDetails customerDetails);
 
     @Operation(summary = "유저 일정 상제 조회하기")
-    ApiResponse<?> getUserSchedule(CustomerDetails customerDetails, Long scheduleId);
+    ApiResponse<ScheduleResponse> getUserSchedule(CustomerDetails customerDetails, Long scheduleId);
 
     @Operation(summary = "유저 일정 삭제하기")
-    ApiResponse<?> deleteUserSchedule(
+    ApiResponse<Long> deleteUserSchedule(
         CustomerDetails customerDetails,
         Long scheduleId
     );
-
-//    @Operation(summary = "유저 일정안에 장소 추가하기")
-//    ApiResponse<?> addPlaceInSchedule(
-//        CustomerDetails customerDetails,
-//        Long scheduleId,
-//        PlaceInfoRequestDto placeInfoRequestDto
-//    );
 }

--- a/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleControllerDocs.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/api/ScheduleControllerDocs.java
@@ -15,7 +15,7 @@ public interface ScheduleControllerDocs {
     @Operation(summary = "새로운 일정 만들기, 빈 일정입니다.")
     ApiResponse<?> createSchedule(CustomerDetails customerDetails);
 
-    @Operation(summary = "일정 수정하기, put 메서드")
+    @Operation(summary = "일정 수정하기, patch 메서드")
     ApiResponse<Long> updateSchedule(
         CustomerDetails customerDetails,
         Long scheduleId,

--- a/src/main/java/com/cliptripbe/feature/schedule/domain/entity/Schedule.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/domain/entity/Schedule.java
@@ -62,12 +62,16 @@ public class Schedule {
         this.schedulePlaceList.add(schedulePlace);
     }
 
-    public void modifyInfo(String name, String description) {
+    public void modifyName(String name) {
         this.name = name;
+    }
+
+    public void modifyDescription(String description) {
         this.description = description;
     }
 
-    public void clear() {
+    public void clearSchedulePlaceList() {
         this.schedulePlaceList.clear();
     }
 }
+

--- a/src/main/java/com/cliptripbe/feature/schedule/dto/request/PlaceWithOrderRequest.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/dto/request/PlaceWithOrderRequest.java
@@ -1,0 +1,12 @@
+package com.cliptripbe.feature.schedule.dto.request;
+
+import com.cliptripbe.feature.place.dto.request.PlaceInfoRequest;
+import lombok.Builder;
+
+@Builder
+public record PlaceWithOrderRequest(
+    Integer placeOrder,
+    PlaceInfoRequest placeInfo
+) {
+
+}

--- a/src/main/java/com/cliptripbe/feature/schedule/dto/request/UpdateScheduleRequest.java
+++ b/src/main/java/com/cliptripbe/feature/schedule/dto/request/UpdateScheduleRequest.java
@@ -1,12 +1,11 @@
 package com.cliptripbe.feature.schedule.dto.request;
 
-import com.cliptripbe.feature.place.dto.request.PlaceInfoRequest;
 import java.util.List;
 
 public record UpdateScheduleRequest(
     String scheduleName,
     String description,
-    List<PlaceInfoRequest> placeInfoRequests
+    List<PlaceWithOrderRequest> placeInfoRequests
 ) {
 
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 일정 수정 put 메소드에서 patch 메소드로 변경하엿습니다
- 일정 수정을 통해 장소 추가 시 저장소에 장소가 있는지 확인 후 없으면 새로 생성하여 추가하였습니다.

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 일정 수정에서 장소 순서 지정 지원; 제공 시 장소 목록을 새로 반영하고 이름/설명은 개별적으로 선택 수정 가능.
- Refactor
  - 장소 응답 생성 로직을 개선해 언어별 응답을 일관되게 제공하도록 변경.
  - 일부 트랜잭션 범위 조정으로 장소 생성/조회 흐름을 안정화.
- Bug Fixes
  - 사용자별 북마크 반영 및 장소 생성/매칭 신뢰성 개선으로 중복·누락 감소.
- Documentation
  - 스케줄 API 문서에 PATCH 및 구체 응답 타입 반영, 사용하지 않는 문서 항목 정리.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->