### PR TITLE
[CTTSK-48] feat: place image pre-signed으로 응답 변경

### DIFF
--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceImageService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceImageService.java
@@ -5,7 +5,6 @@ import com.cliptripbe.infrastructure.port.google.PlaceImageProviderPort;
 import com.cliptripbe.infrastructure.port.s3.FileStoragePort;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -16,11 +15,10 @@ public class PlaceImageService {
     private final FileStoragePort fileStoragePort;
     private final PlaceImageProviderPort placeImageProviderPort;
 
-
     public void savePlaceImage(Place place) {
         String searchKeyWord = place.getName() + " " + place.getAddress().roadAddress();
         byte[] imageBytes = placeImageProviderPort.getPhotoByAddress(searchKeyWord);
-        String imageUrl = fileStoragePort.upload(S3_PLACE_PREFIX, imageBytes);
-        place.addImageUrl(imageUrl);
+        String imageKey = fileStoragePort.upload(S3_PLACE_PREFIX, imageBytes);
+        place.addImageKey(imageKey);
     }
 }

--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -78,7 +78,7 @@ public class PlaceService {
         List<Long> bookmarkedIdList = bookmarkFinder.findBookmarkIdsByUserIdAndPlaceId(
             user.getId(), place.getId());
 
-        String presignedUrl = fileStoragePort.generatePresignedUrl(
+        String presignedUrl = fileStoragePort.generatePresignedUrlForDownload(
             place.getImageKey(), Duration.ofMinutes(15));
 
         // TODO : 여기도 번역 적용해주세요.
@@ -98,7 +98,7 @@ public class PlaceService {
             placeImageService.savePlaceImage(place);
         }
 
-        String presignedUrl = fileStoragePort.generatePresignedUrl(
+        String presignedUrl = fileStoragePort.generatePresignedUrlForDownload(
             place.getImageKey(), Duration.ofMinutes(15));
 
         List<Long> bookmarkedIdList = bookmarkFinder.findBookmarkIdsByUserIdAndPlaceId(

--- a/src/main/java/com/cliptripbe/feature/place/domain/entity/Place.java
+++ b/src/main/java/com/cliptripbe/feature/place/domain/entity/Place.java
@@ -51,7 +51,7 @@ public class Place extends BaseTimeEntity {
     private PlaceType placeType;
 
     @Column
-    private String imageUrl;
+    private String imageKey;
 
     @Column(unique = true)
     private String kakaoPlaceId;
@@ -66,7 +66,7 @@ public class Place extends BaseTimeEntity {
         Address address,
         Set<AccessibilityFeature> accessibilityFeatures,
         PlaceType placeType,
-        String imageUrl,
+        String imageKey,
         String kakaoPlaceId
     ) {
         this.name = name;
@@ -76,12 +76,12 @@ public class Place extends BaseTimeEntity {
             ? new HashSet<>(accessibilityFeatures)
             : new HashSet<>();
         this.placeType = placeType;
-        this.imageUrl = imageUrl;
+        this.imageKey = imageKey;
         this.kakaoPlaceId = kakaoPlaceId;
     }
 
-    public void addImageUrl(String imageUrl) {
-        this.imageUrl = imageUrl;
+    public void addImageKey(String imageKey) {
+        this.imageKey = imageKey;
     }
 
     public PlaceTranslation getTranslationByLanguage(Language language) {
@@ -107,6 +107,10 @@ public class Place extends BaseTimeEntity {
 
     public void addKakaoPlaceId(String kakaoPlaceId) {
         this.kakaoPlaceId = kakaoPlaceId;
+    }
+
+    public boolean hasImageKey() {
+        return imageKey != null && !imageKey.isBlank();
     }
 
 }

--- a/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceResponse.java
+++ b/src/main/java/com/cliptripbe/feature/place/dto/response/PlaceResponse.java
@@ -23,7 +23,7 @@ public record PlaceResponse(
     String kakaoPlaceId
 ) {
 
-    public static PlaceResponse of(Place place, List<Long> bookmarkedIdList) {
+    public static PlaceResponse of(Place place, List<Long> bookmarkedIdList, String presignedUrl) {
         return PlaceResponse.builder()
             .placeId(place.getId())
             .placeName(place.getName())
@@ -33,7 +33,7 @@ public record PlaceResponse(
             .longitude(place.getAddress().longitude())
             .latitude(place.getAddress().latitude())
             .accessibilityFeatures(place.getAccessibilityFeatures())
-            .imageUrl(place.getImageUrl())
+            .imageUrl(presignedUrl)
             .bookmarkedIdList(bookmarkedIdList)
             .kakaoPlaceId(place.getKakaoPlaceId())
             .build();
@@ -42,7 +42,8 @@ public record PlaceResponse(
     public static PlaceResponse ofTranslation(
         Place place,
         List<Long> bookmarkedIdList,
-        PlaceTranslation placeTranslation
+        PlaceTranslation placeTranslation,
+        String presignedUrl
     ) {
         return PlaceResponse.builder()
             .placeId(place.getId())
@@ -53,7 +54,7 @@ public record PlaceResponse(
             .longitude(place.getAddress().longitude())
             .latitude(place.getAddress().latitude())
             .accessibilityFeatures(place.getAccessibilityFeatures())
-            .imageUrl(place.getImageUrl())
+            .imageUrl(presignedUrl)
             .bookmarkedIdList(bookmarkedIdList)
             .kakaoPlaceId(place.getKakaoPlaceId())
             .build();

--- a/src/main/java/com/cliptripbe/feature/user/domain/entity/User.java
+++ b/src/main/java/com/cliptripbe/feature/user/domain/entity/User.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@Table(name = "user_table")
+@Table(name = "user")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class User {
 

--- a/src/main/java/com/cliptripbe/global/config/S3Config.java
+++ b/src/main/java/com/cliptripbe/global/config/S3Config.java
@@ -7,6 +7,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 
 @Configuration
 public class S3Config {
@@ -24,6 +25,15 @@ public class S3Config {
     public S3Client s3Client() {
         AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
         return S3Client.builder()
+            .region(Region.of(region))
+            .credentialsProvider(StaticCredentialsProvider.create(credentials))
+            .build();
+    }
+
+    @Bean
+    public S3Presigner s3Presigner() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+        return S3Presigner.builder()
             .region(Region.of(region))
             .credentialsProvider(StaticCredentialsProvider.create(credentials))
             .build();

--- a/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
+++ b/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
@@ -50,7 +50,11 @@ public enum ErrorType {
 
     // kakaoMobility
     KAKAO_MOBILITY_NO_RESPONSE(HttpStatus.BAD_GATEWAY, "kakaoMobility로부터 응답을 받지 못했습니다."),
-    FAIL_KAKAO_MOBILITY(HttpStatus.BAD_GATEWAY, "kakaoMobility 서비스 호출 실패");
+    FAIL_KAKAO_MOBILITY(HttpStatus.BAD_GATEWAY, "kakaoMobility 서비스 호출 실패"),
+
+    // s3
+    FAIL_GENERATE_PRESIGNED_URL(HttpStatus.INTERNAL_SERVER_ERROR, "pre-signed url 생성에 실패했습니다."),
+    ;
 
 
     private final HttpStatus httpStatusCode;

--- a/src/main/java/com/cliptripbe/infrastructure/adapter/out/s3/S3Adapter.java
+++ b/src/main/java/com/cliptripbe/infrastructure/adapter/out/s3/S3Adapter.java
@@ -1,9 +1,13 @@
 package com.cliptripbe.infrastructure.adapter.out.s3;
 
+import static com.cliptripbe.global.response.type.ErrorType.FAIL_GENERATE_PRESIGNED_URL;
+
+import com.cliptripbe.global.response.exception.CustomException;
 import com.cliptripbe.infrastructure.port.s3.FileStoragePort;
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -15,12 +19,16 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedGetObjectRequest;
 
 @Component
 @RequiredArgsConstructor
 public class S3Adapter implements FileStoragePort {
 
     private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
     private final Region awsRegion;
 
     @Value("${s3.bucket}")
@@ -48,10 +56,30 @@ public class S3Adapter implements FileStoragePort {
             .build();
 
         s3Client.putObject(req, RequestBody.fromBytes(data));
-        return String.format("https://%s.s3.%s.amazonaws.com/%s",
-            bucket,
-            awsRegion.id(),
-            fullKey
-        );
+
+        return fullKey;
+    }
+
+    @Override
+    public String generatePresignedUrl(String key, Duration expiration) {
+        try {
+            GetObjectRequest getRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+            GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(expiration)
+                .getObjectRequest(getRequest)
+                .build();
+
+            PresignedGetObjectRequest presignedRequest = s3Presigner.presignGetObject(
+                presignRequest);
+
+            return presignedRequest.url().toString();
+
+        } catch (Exception e) {
+            throw new CustomException(FAIL_GENERATE_PRESIGNED_URL);
+        }
     }
 }

--- a/src/main/java/com/cliptripbe/infrastructure/adapter/out/s3/S3Adapter.java
+++ b/src/main/java/com/cliptripbe/infrastructure/adapter/out/s3/S3Adapter.java
@@ -61,7 +61,7 @@ public class S3Adapter implements FileStoragePort {
     }
 
     @Override
-    public String generatePresignedUrl(String key, Duration expiration) {
+    public String generatePresignedUrlForDownload(String key, Duration expiration) {
         try {
             GetObjectRequest getRequest = GetObjectRequest.builder()
                 .bucket(bucket)

--- a/src/main/java/com/cliptripbe/infrastructure/adapter/out/s3/S3Adapter.java
+++ b/src/main/java/com/cliptripbe/infrastructure/adapter/out/s3/S3Adapter.java
@@ -16,7 +16,6 @@ import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-
 @Component
 @RequiredArgsConstructor
 public class S3Adapter implements FileStoragePort {

--- a/src/main/java/com/cliptripbe/infrastructure/port/s3/FileStoragePort.java
+++ b/src/main/java/com/cliptripbe/infrastructure/port/s3/FileStoragePort.java
@@ -5,5 +5,6 @@ import java.io.BufferedReader;
 public interface FileStoragePort {
 
     BufferedReader readCsv(String key);
+
     String upload(String key, byte[] data);
 }

--- a/src/main/java/com/cliptripbe/infrastructure/port/s3/FileStoragePort.java
+++ b/src/main/java/com/cliptripbe/infrastructure/port/s3/FileStoragePort.java
@@ -1,10 +1,13 @@
 package com.cliptripbe.infrastructure.port.s3;
 
 import java.io.BufferedReader;
+import java.time.Duration;
 
 public interface FileStoragePort {
 
     BufferedReader readCsv(String key);
 
     String upload(String key, byte[] data);
+
+    String generatePresignedUrl(String key, Duration expiration);
 }

--- a/src/main/java/com/cliptripbe/infrastructure/port/s3/FileStoragePort.java
+++ b/src/main/java/com/cliptripbe/infrastructure/port/s3/FileStoragePort.java
@@ -9,5 +9,5 @@ public interface FileStoragePort {
 
     String upload(String key, byte[] data);
 
-    String generatePresignedUrl(String key, Duration expiration);
+    String generatePresignedUrlForDownload(String key, Duration expiration);
 }


### PR DESCRIPTION
## ✅ 작업 내용
- 장소 상세 조회 시 응답하는 이미지 주소를 pre-signed로 변경하였습니다

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 장소 이미지에 대해 만료 시간(예: 15분)의 임시 접근 링크를 생성·제공
  - 임시 링크 생성 실패 시 사용자용 오류 타입 및 메시지 추가

- Refactor
  - 이미지 저장 방식을 외부 URL 보관에서 내부 키(key) 보관으로 전환
  - 모든 응답에 임시 접근 링크를 포함하도록 변경

- Chores
  - 임시 링크 생성을 위한 스토리지 구성 요소 추가
  - 엔티티 매핑 조정 및 불필요한 코드 정리
<!-- end of auto-generated comment: release notes by coderabbit.ai -->