### PR TITLE
[Feat] : video 추출 시 레이턴시가 길어 멱등을 보장하기 위한 aop 구현

### DIFF
--- a/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
+++ b/src/main/java/com/cliptripbe/feature/place/application/PlaceService.java
@@ -271,15 +271,6 @@ public class PlaceService {
         List<Place> placesInRange = placeClassifier.getLuggagePlacesByRange(luggageStorageRequest,
             luggageStoragePlaces);
 
-//        List<PlaceDto> placeDtoList = placesInRange.stream()
-//            .map(PlaceDto::fromEntity)
-//            .toList();
-
-//        Map<String, List<Long>> stringKeyBookmarkMap = bookmarkIdsMap.entrySet().stream()
-//            .collect(Collectors.toMap(
-//                entry -> String.valueOf(entry.getKey()),
-//                Map.Entry::getValue
-//            ));
         return PlaceListResponseAssembler.createPlaceListResponseForLuggage(placesInRange,
             bookmarkIdsMap, user);
     }

--- a/src/main/java/com/cliptripbe/feature/video/api/VideoController.java
+++ b/src/main/java/com/cliptripbe/feature/video/api/VideoController.java
@@ -5,7 +5,6 @@ import static com.cliptripbe.global.constant.Constant.API_VERSION;
 import com.cliptripbe.feature.video.application.VideoPlaceExtractFacade;
 import com.cliptripbe.feature.video.dto.request.ExtractPlaceRequest;
 import com.cliptripbe.feature.video.dto.response.VideoScheduleResponse;
-import com.cliptripbe.feature.video.application.VideoService;
 import com.cliptripbe.global.aop.idempotency.annotation.Idempotent;
 import com.cliptripbe.global.auth.security.CustomerDetails;
 import com.cliptripbe.global.response.ApiResponse;

--- a/src/main/java/com/cliptripbe/feature/video/api/VideoController.java
+++ b/src/main/java/com/cliptripbe/feature/video/api/VideoController.java
@@ -6,6 +6,7 @@ import com.cliptripbe.feature.video.application.VideoPlaceExtractFacade;
 import com.cliptripbe.feature.video.dto.request.ExtractPlaceRequest;
 import com.cliptripbe.feature.video.dto.response.VideoScheduleResponse;
 import com.cliptripbe.feature.video.application.VideoService;
+import com.cliptripbe.global.aop.idempotency.annotation.Idempotent;
 import com.cliptripbe.global.auth.security.CustomerDetails;
 import com.cliptripbe.global.response.ApiResponse;
 import com.cliptripbe.global.response.type.SuccessType;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -24,10 +26,12 @@ public class VideoController implements VideoControllerDocs {
 
     private final VideoPlaceExtractFacade videoPlaceExtractFacade;
 
+    @Idempotent
     @PostMapping()
     public ApiResponse<VideoScheduleResponse> extractPlacesFromYoutube(
         @AuthenticationPrincipal CustomerDetails customerDetails,
-        @Valid @RequestBody ExtractPlaceRequest request
+        @Valid @RequestBody ExtractPlaceRequest request,
+        @RequestHeader("Idempotency-Key") String idempotencyKey
     ) {
         VideoScheduleResponse videoScheduleResponse = videoPlaceExtractFacade.extractPlace(
             customerDetails.getUser(),

--- a/src/main/java/com/cliptripbe/feature/video/api/VideoControllerDocs.java
+++ b/src/main/java/com/cliptripbe/feature/video/api/VideoControllerDocs.java
@@ -5,6 +5,7 @@ import com.cliptripbe.feature.video.dto.response.VideoScheduleResponse;
 import com.cliptripbe.global.auth.security.CustomerDetails;
 import com.cliptripbe.global.response.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "유튜브 영상 관련 API")
@@ -13,6 +14,9 @@ public interface VideoControllerDocs {
     @Operation(summary = "장소 추출하기, \n로그인 필요")
     ApiResponse<VideoScheduleResponse> extractPlacesFromYoutube(
         CustomerDetails customerDetails,
-        ExtractPlaceRequest request
+        ExtractPlaceRequest request,
+
+        @Parameter(description = "멱등 키", required = true, example = "391dc8ed-6210-42ed-9eb2-8b2c9cd56542")
+        String idempotencyKey
     );
 }

--- a/src/main/java/com/cliptripbe/global/aop/idempotency/annotation/Idempotent.java
+++ b/src/main/java/com/cliptripbe/global/aop/idempotency/annotation/Idempotent.java
@@ -1,0 +1,12 @@
+package com.cliptripbe.global.aop.idempotency.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Idempotent {
+
+}

--- a/src/main/java/com/cliptripbe/global/aop/idempotency/aspect/IdempotencyAspect.java
+++ b/src/main/java/com/cliptripbe/global/aop/idempotency/aspect/IdempotencyAspect.java
@@ -1,0 +1,103 @@
+package com.cliptripbe.global.aop.idempotency.aspect;
+
+import com.cliptripbe.global.aop.idempotency.entity.IdempotencyKey;
+import com.cliptripbe.global.aop.idempotency.entity.RequestStatus;
+import com.cliptripbe.global.aop.idempotency.repository.IdempotencyKeyRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+@Slf4j
+@Aspect
+@Component
+@RequiredArgsConstructor
+public class IdempotencyAspect {
+
+    private static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
+
+    private final IdempotencyKeyRepository idempotencyKeyRepository;
+    private final ObjectMapper objectMapper;
+
+
+    @Around("@annotation(com.cliptripbe.global.aop.idempotency.annotation.Idempotent)")
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public Object handleIdempotency(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        HttpServletRequest request = ((ServletRequestAttributes) RequestContextHolder.currentRequestAttributes()).getRequest();
+        final String idempotencyKey = request.getHeader(IDEMPOTENCY_KEY_HEADER);
+
+        if (idempotencyKey == null || idempotencyKey.isEmpty()) {
+            return joinPoint.proceed();
+        }
+
+        var existingKey = idempotencyKeyRepository.findById(idempotencyKey);
+        if (existingKey.isPresent()) {
+            IdempotencyKey storedKey = existingKey.get();
+            if (storedKey.getStatus() == RequestStatus.COMPLETED) {
+                log.info("Returning stored response for key: {}", idempotencyKey);
+                String storedResponseBody = storedKey.getResponseBody();
+
+                // 2. 저장된 JSON을 실제 반환 타입의 객체로 역직렬화
+                MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+                Class<?> returnType = signature.getReturnType();
+                Object storedResponse = objectMapper.readValue(storedResponseBody, returnType);
+
+                // 컨트롤러가 ResponseEntity를 직접 반환하는 경우를 위해 상태 코드도 사용
+                // 여기서는 ApiResponse를 반환하므로 Spring이 자동으로 200 OK로 처리해줍니다.
+                return storedResponse;
+            } else { // PROCESSING
+                log.warn("Request already in progress for key: {}", idempotencyKey);
+                return new ResponseEntity<>("Request is already in progress.", HttpStatus.CONFLICT);
+            }
+        }
+
+        try {
+            idempotencyKeyRepository.save(new IdempotencyKey(idempotencyKey));
+        } catch (DataIntegrityViolationException e) {
+            log.warn("Concurrent request detected by unique constraint for key: {}",
+                idempotencyKey);
+            return new ResponseEntity<>("Request is already in progress.", HttpStatus.CONFLICT);
+        }
+
+        try {
+            // 3. 반환 타입을 Object로 변경하여 모든 타입의 응답을 받음
+            Object response = joinPoint.proceed();
+
+            // 4. 응답 객체를 JSON 문자열로 직렬화
+            String responseBodyJson = objectMapper.writeValueAsString(response);
+
+            IdempotencyKey keyToComplete = idempotencyKeyRepository.findById(idempotencyKey)
+                .orElseThrow(() -> new IllegalStateException(
+                    "Idempotency key not found after processing: " + idempotencyKey));
+
+            // 응답이 ResponseEntity인 경우 실제 상태 코드를, 아닌 경우 200 OK를 사용
+//            HttpStatusCode statusCode = (response instanceof ResponseEntity)
+//                ? ((ResponseEntity<?>) response).getStatusCode()
+//                : HttpStatus.OK;
+
+            keyToComplete.complete(responseBodyJson);
+            idempotencyKeyRepository.save(keyToComplete);
+
+            return response;
+        } catch (Exception e) {
+            log.error("Error during processing for key: {}. Removing key.", idempotencyKey, e);
+            idempotencyKeyRepository.deleteById(idempotencyKey);
+            throw e;
+        }
+    }
+
+}

--- a/src/main/java/com/cliptripbe/global/aop/idempotency/entity/IdempotencyKey.java
+++ b/src/main/java/com/cliptripbe/global/aop/idempotency/entity/IdempotencyKey.java
@@ -1,0 +1,48 @@
+package com.cliptripbe.global.aop.idempotency.entity;
+
+import com.cliptripbe.global.entity.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.Lob;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatusCode;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "idempotency_keys")
+public class IdempotencyKey extends BaseTimeEntity {
+
+    @Id
+    @Column(name = "idempotency_key")
+    private String key;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private RequestStatus status;
+
+
+    @Lob
+    @Column(name = "response_body", columnDefinition = "LONGTEXT")
+    private String responseBody;
+
+
+    public IdempotencyKey(String key) {
+        this.key = key;
+        this.status = RequestStatus.PROCESSING;
+
+    }
+
+    public void complete(String body) {
+        this.status = RequestStatus.COMPLETED;
+        this.responseBody = body;
+    }
+}
+

--- a/src/main/java/com/cliptripbe/global/aop/idempotency/entity/IdempotencyKey.java
+++ b/src/main/java/com/cliptripbe/global/aop/idempotency/entity/IdempotencyKey.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.http.HttpStatusCode;
 
 @Entity
 @Getter
@@ -28,21 +27,27 @@ public class IdempotencyKey extends BaseTimeEntity {
     @Column(nullable = false)
     private RequestStatus status;
 
-
     @Lob
     @Column(name = "response_body", columnDefinition = "LONGTEXT")
     private String responseBody;
+
+    @Column(name = "expires_at", nullable = false)
+    private LocalDateTime expiresAt;
 
 
     public IdempotencyKey(String key) {
         this.key = key;
         this.status = RequestStatus.PROCESSING;
-
+        this.expiresAt = LocalDateTime.now().plusHours(24);
     }
 
     public void complete(String body) {
         this.status = RequestStatus.COMPLETED;
         this.responseBody = body;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(expiresAt);
     }
 }
 

--- a/src/main/java/com/cliptripbe/global/aop/idempotency/entity/RequestStatus.java
+++ b/src/main/java/com/cliptripbe/global/aop/idempotency/entity/RequestStatus.java
@@ -1,0 +1,7 @@
+package com.cliptripbe.global.aop.idempotency.entity;
+
+public enum RequestStatus {
+    PROCESSING,
+    COMPLETED,
+    FAILED
+}

--- a/src/main/java/com/cliptripbe/global/aop/idempotency/repository/IdempotencyKeyRepository.java
+++ b/src/main/java/com/cliptripbe/global/aop/idempotency/repository/IdempotencyKeyRepository.java
@@ -1,0 +1,10 @@
+package com.cliptripbe.global.aop.idempotency.repository;
+
+import com.cliptripbe.global.aop.idempotency.entity.IdempotencyKey;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface IdempotencyKeyRepository extends JpaRepository<IdempotencyKey, String> {
+
+}

--- a/src/main/java/com/cliptripbe/global/response/ApiResponse.java
+++ b/src/main/java/com/cliptripbe/global/response/ApiResponse.java
@@ -1,10 +1,12 @@
 package com.cliptripbe.global.response;
 
+import com.cliptripbe.global.response.serializer.HttpStatusCodeDeserializer;
 import com.cliptripbe.global.response.type.ErrorType;
 import com.cliptripbe.global.response.type.ResultType;
 import com.cliptripbe.global.response.type.SuccessType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import org.springframework.http.HttpStatusCode;
@@ -15,10 +17,14 @@ import org.springframework.http.HttpStatusCode;
 public record ApiResponse<T>(
     @Schema(description = "응답 타입", example = "SUCCESS")
     ResultType resultType,
+
     @Schema(description = "응답 코드", example = "200")
+    @JsonDeserialize(using = HttpStatusCodeDeserializer.class)
     HttpStatusCode httpStatusCode,
+
     @Schema(description = "응답 내용", example = "요청에 성공하였습니다.")
     String message,
+
     @JsonInclude(JsonInclude.Include.NON_NULL)
     T data
 ) {

--- a/src/main/java/com/cliptripbe/global/response/serializer/HttpStatusCodeDeserializer.java
+++ b/src/main/java/com/cliptripbe/global/response/serializer/HttpStatusCodeDeserializer.java
@@ -1,0 +1,28 @@
+package com.cliptripbe.global.response.serializer;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import java.io.IOException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+
+public class HttpStatusCodeDeserializer extends JsonDeserializer<HttpStatusCode> {
+
+    @Override
+    public HttpStatusCode deserialize(JsonParser p, DeserializationContext ctxt)
+        throws IOException {
+
+        String text = p.getText();
+
+        if (text == null || text.isEmpty()) {
+            return null;
+        }
+
+        try {
+            return HttpStatus.valueOf(text);
+        } catch (IllegalArgumentException e) {
+            return HttpStatus.OK;
+        }
+    }
+}

--- a/src/main/java/com/cliptripbe/global/response/serializer/HttpStatusCodeDeserializer.java
+++ b/src/main/java/com/cliptripbe/global/response/serializer/HttpStatusCodeDeserializer.java
@@ -9,6 +9,23 @@ import org.springframework.http.HttpStatusCode;
 
 public class HttpStatusCodeDeserializer extends JsonDeserializer<HttpStatusCode> {
 
+//    @Override
+//    public HttpStatusCode deserialize(JsonParser p, DeserializationContext ctxt)
+//        throws IOException {
+//
+//        String text = p.getText();
+//
+//        if (text == null || text.isEmpty()) {
+//            return null;
+//        }
+//
+//        try {
+//            return HttpStatus.valueOf(text);
+//        } catch (IllegalArgumentException e) {
+//            return HttpStatus.OK;
+//        }
+//    }
+
     @Override
     public HttpStatusCode deserialize(JsonParser p, DeserializationContext ctxt)
         throws IOException {
@@ -22,7 +39,10 @@ public class HttpStatusCodeDeserializer extends JsonDeserializer<HttpStatusCode>
         try {
             return HttpStatus.valueOf(text);
         } catch (IllegalArgumentException e) {
-            return HttpStatus.OK;
+            throw new IOException(
+                "Invalid HTTP status code: '" + text + "'. " +
+                    "This indicates data corruption or version mismatch.", e
+            );
         }
     }
 }

--- a/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
+++ b/src/main/java/com/cliptripbe/global/response/type/ErrorType.java
@@ -57,6 +57,10 @@ public enum ErrorType {
 
     // s3
     FAIL_GENERATE_PRESIGNED_URL(HttpStatus.INTERNAL_SERVER_ERROR, "pre-signed url 생성에 실패했습니다."),
+
+    // idempotent
+    REQUEST_ALREADY_IN_PROGRESS(HttpStatus.CONFLICT, "이미 처리 중인 요청입니다."),
+
     ;
 
 


### PR DESCRIPTION
## ✅ 작업 내용
- video 추출시 네트워크 유실, 새로고침 등 유실이 있을 시 멱등을 보장하기 위한 aop 구현

## 🤔 고민 했던 부분
- 고민했던 포인트가 없다면 **삭제**해도 됩니다.
- **어떤 고민**을 해서 **어떤 결과**가 나왔는지 작성해주세요.
- 경험 공유나 다른 팀원들의 생각을 들을 수 있을 것 같아요.

## 🚨 참고 사항
- 참고한 래퍼런스나 자료가 있으면 올려주세요.

## 🔊 도움이 필요한 부분
- 도움이 필요한 부분이 없다면 **삭제** 해도 됩니다.
- **팀원들의 의견이 꼭 필요한 부분**을 작성해주세요.
- **팀원들은 놓치지 않고 꼭 이 항목을 보고 의견을 주세요.**

## 🚀 기대 효과
- 해당 기능 도입으로 기대되는 효과를 적어주세요.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 동영상에서 장소를 추출하는 API에 멱등성(Idempotency-Key) 지원 추가 (중복/동시 처리 방지)

* **개선**
  * API 응답 직렬화/역직렬화 처리 개선으로 다양한 상태 코드 복원 지원
  * 멱등성 처리 결과 재사용 및 상태 관리 추가

* **문서화**
  * API 명세서에 멱등 키 파라미터 정보 및 사용 예시 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->